### PR TITLE
Unify use of the rid parameter of msgRecv, msgRespond functions

### DIFF
--- a/drivers/telit-le910_host/telit-le910.c
+++ b/drivers/telit-le910_host/telit-le910.c
@@ -85,7 +85,7 @@ typedef struct {
 	void *next, *prev;
 
 	msg_t msg;
-	unsigned rid;
+	unsigned long rid;
 
 	struct _ttyacm_t *acm;
 	usb_urb_t urb;

--- a/host/hostproxy.c
+++ b/host/hostproxy.c
@@ -45,7 +45,7 @@ static char event_loop_stack[4096] __attribute__((aligned(8)));
 void hostproxy_event_loop(void *arg)
 {
 	msg_t msg;
-	unsigned int rid;
+	unsigned long int rid;
 
 	mutexLock(hostproxy_common.lock);
 	while (hostproxy_common.state & HOSTPROXY_RUNNING) {

--- a/host/hostsrv.c
+++ b/host/hostsrv.c
@@ -1002,7 +1002,7 @@ int hostsrv_open(usb_open_t *o, msg_t *msg)
 void msgthr(void *arg)
 {
 	unsigned port = (int)arg;
-	unsigned rid;
+	unsigned long rid;
 	msg_t msg;
 	usb_msg_t *umsg;
 


### PR DESCRIPTION
Accordingly to phoenix-rtos/libphoenix#70 (comment)