### PR TITLE
Add notifications to cdc, event handling to cdc and hid client

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for Phoenix-RTOS usb class lib
 #
-# Copyright 2020 Phoenix Systems
+# Copyright 2020-2021 Phoenix Systems
 #
 
 

--- a/client/cdc_client.c
+++ b/client/cdc_client.c
@@ -172,11 +172,11 @@ static const usb_endpoint_desc_t dEpIN = {
 };
 
 
-/* String Data: Manufacturer */
+/* String Data: Manufacturer = "Phoenix Systems" */
 static const usb_string_desc_t dStrMan = {
 	.bLength = 2 * 15 + 2,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = { 'N', 0, 'X', 0, 'P', 0, ' ', 0, 'S', 0, 'E', 0, 'M', 0, 'I', 0, 'C', 0, 'O', 0, 'N', 0, 'D', 0, 'U', 0, 'C', 0, 'T', 0, 'O', 0, 'R', 0, 'S', 0 }
+	.wData = { 'P', 0, 'h', 0, 'o', 0, 'e', 0, 'n', 0, 'i', 0, 'x', 0, ' ', 0, 'S', 0, 'y', 0, 's', 0, 't', 0, 'e', 0, 'm', 0, 's', 0 }
 };
 
 
@@ -188,11 +188,11 @@ static const usb_string_desc_t dStr0 = {
 };
 
 
-/* String Data: Product */
+/* String Data: Product = "Virtual COM Port" */
 static const usb_string_desc_t dStrProd = {
 	.bLength = 2 * 16 + 2,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = { 'M', 0, 'C', 0, 'U', 0, ' ', 0, 'V', 0, 'I', 0, 'R', 0, 'T', 0, 'U', 0, 'A', 0, 'L', 0 }
+	.wData = { 'V', 0, 'i', 0, 'r', 0, 't', 0, 'u', 0, 'a', 0, 'l', 0, ' ', 0, 'C', 0, 'O', 0, 'M', 0, ' ', 0, 'P', 0, 'o', 0, 'r', 0, 't', 0 }
 };
 
 

--- a/client/cdc_client.c
+++ b/client/cdc_client.c
@@ -3,8 +3,8 @@
  *
  * cdc - USB Communication Device Class
  *
- * Copyright 2019 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -14,12 +14,10 @@
 
 #include <errno.h>
 #include <stdio.h>
-
 #include <sys/list.h>
-
 #include <usbclient.h>
-
 #include "cdc_client.h"
+
 
 struct {
 	usb_desc_list_t *descList;
@@ -45,113 +43,170 @@ struct {
 
 
 /* Device descriptor */
-static const usb_device_desc_t ddev = { .bLength = sizeof(usb_device_desc_t), .bDescriptorType = USB_DESC_DEVICE, .bcdUSB = 0x0002,
-	.bDeviceClass = 0x0, .bDeviceSubClass = 0, .bDeviceProtocol = 0, .bMaxPacketSize0 = 64,
-	.idVendor = 0x16f9, .idProduct = 0x0003, .bcdDevice = 0x0200,
-	.iManufacturer = 1, .iProduct = 2, .iSerialNumber = 0,
-	.bNumConfigurations = 1 };
+static const usb_device_desc_t dDev = {
+	.bLength = sizeof(usb_device_desc_t),
+	.bDescriptorType = USB_DESC_DEVICE,
+	.bcdUSB = 0x0002,
+	.bDeviceClass = 0x0,
+	.bDeviceSubClass = 0,
+	.bDeviceProtocol = 0,
+	.bMaxPacketSize0 = 64,
+	.idVendor = 0x16f9,
+	.idProduct = 0x0003,
+	.bcdDevice = 0x0200,
+	.iManufacturer = 1,
+	.iProduct = 2,
+	.iSerialNumber = 0,
+	.bNumConfigurations = 1
+};
 
 
 /* Configuration descriptor */
-static const usb_configuration_desc_t dconfig = { .bLength = 9, .bDescriptorType = USB_DESC_CONFIG,
-	.wTotalLength = sizeof(usb_configuration_desc_t) + sizeof(usb_interface_desc_t) + sizeof(usb_desc_cdc_header_t) + sizeof(usb_desc_cdc_call_t)
-	+ sizeof(usb_desc_cdc_acm_t) + sizeof(usb_desc_cdc_union_t) + sizeof(usb_endpoint_desc_t) + sizeof(usb_interface_desc_t) + sizeof(usb_endpoint_desc_t) + sizeof(usb_endpoint_desc_t),
-	.bNumInterfaces = 2, .bConfigurationValue = 1, .iConfiguration = 0, .bmAttributes = 0xc0, .bMaxPower = 5 };
+static const usb_configuration_desc_t dConfig = {
+	.bLength = 9,
+	.bDescriptorType = USB_DESC_CONFIG,
+	.wTotalLength = sizeof(usb_configuration_desc_t) + sizeof(usb_interface_desc_t) + sizeof(usb_desc_cdc_header_t)
+		+ sizeof(usb_desc_cdc_call_t) + sizeof(usb_desc_cdc_acm_t) + sizeof(usb_desc_cdc_union_t)
+		+ sizeof(usb_endpoint_desc_t) + sizeof(usb_interface_desc_t) + sizeof(usb_endpoint_desc_t)
+		+ sizeof(usb_endpoint_desc_t),
+	.bNumInterfaces = 2,
+	.bConfigurationValue = 1,
+	.iConfiguration = 0,
+	.bmAttributes = 0xc0,
+	.bMaxPower = 5
+};
 
 
 /* Communication Interface Descriptor */
-static const usb_interface_desc_t dComIntf =  { .bLength = 9, .bDescriptorType = USB_DESC_INTERFACE, .bInterfaceNumber = 0, .bAlternateSetting = 0,
-	.bNumEndpoints = 1, .bInterfaceClass = 0x02, .bInterfaceSubClass = 0x02, .bInterfaceProtocol = 0x00, .iInterface = 4 };
+static const usb_interface_desc_t dComIface = {
+	.bLength = 9,
+	.bDescriptorType = USB_DESC_INTERFACE,
+	.bInterfaceNumber = 0,
+	.bAlternateSetting = 0,
+	.bNumEndpoints = 1,
+	.bInterfaceClass = 0x02,
+	.bInterfaceSubClass = 0x02,
+	.bInterfaceProtocol = 0x00,
+	.iInterface = 4
+};
 
 
-static const usb_desc_cdc_header_t dHeader = { .bLength = 5, .bType = USB_DESC_TYPE_CDC_CS_INTERFACE, .bSubType = 0, .bcdCDC = 0x0110 };
+static const usb_desc_cdc_header_t dHeader = {
+	.bLength = 5,
+	.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+	.bSubType = 0,
+	.bcdCDC = 0x0110
+};
 
 
-static const usb_desc_cdc_call_t dCall = { .bLength = 5, .bType = USB_DESC_TYPE_CDC_CS_INTERFACE, .bSubType = 0x01, .bmCapabilities = 0x01, .bDataInterface = 0x1 };
+static const usb_desc_cdc_call_t dCall = {
+	.bLength = 5,
+	.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+	.bSubType = 0x01,
+	.bmCapabilities = 0x01,
+	.bDataInterface = 0x1
+};
 
 
-static const usb_desc_cdc_acm_t dAcm = { .bLength = 4, .bType = USB_DESC_TYPE_CDC_CS_INTERFACE, .bSubType = 0x02, .bmCapabilities = 0x03 };
+static const usb_desc_cdc_acm_t dAcm = {
+	.bLength = 4,
+	.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+	.bSubType = 0x02,
+	.bmCapabilities = 0x03
+};
 
 
-static const usb_desc_cdc_union_t dUnion = { .bLength = 5, .bType = USB_DESC_TYPE_CDC_CS_INTERFACE, .bSubType = 0x06, .bControlInterface = 0x0, .bSubordinateInterface = 0x1};
+static const usb_desc_cdc_union_t dUnion = {
+	.bLength = 5,
+	.bType = USB_DESC_TYPE_CDC_CS_INTERFACE,
+	.bSubType = 0x06,
+	.bControlInterface = 0x0,
+	.bSubordinateInterface = 0x1
+};
 
 
 /* Communication Interrupt Endpoint IN */
-static const usb_endpoint_desc_t dComEp = { .bLength = 7, .bDescriptorType = USB_DESC_ENDPOINT, .bEndpointAddress = 0x81	, /* direction IN */
-	.bmAttributes = 0x03, .wMaxPacketSize = 0x20, .bInterval = 0x08
+static const usb_endpoint_desc_t dComEp = {
+	.bLength = 7,
+	.bDescriptorType = USB_DESC_ENDPOINT,
+	.bEndpointAddress = 0x81, /* direction IN */
+	.bmAttributes = 0x03,
+	.wMaxPacketSize = 0x20,
+	.bInterval = 0x08
 };
 
 
 /* CDC Data Interface Descriptor */
-static const usb_interface_desc_t dDataIntf = { .bLength = 9, .bDescriptorType = USB_DESC_INTERFACE, .bInterfaceNumber = 1, .bAlternateSetting = 0,
-	 .bNumEndpoints = 2, .bInterfaceClass = 0x0a, .bInterfaceSubClass = 0x00, .bInterfaceProtocol = 0x00, .iInterface = 0
+static const usb_interface_desc_t dDataIface = {
+	.bLength = 9,
+	.bDescriptorType = USB_DESC_INTERFACE,
+	.bInterfaceNumber = 1,
+	.bAlternateSetting = 0,
+	.bNumEndpoints = 2,
+	.bInterfaceClass = 0x0a,
+	.bInterfaceSubClass = 0x00,
+	.bInterfaceProtocol = 0x00,
+	.iInterface = 0
 };
 
 
 /* Data Bulk Endpoint OUT */
-static const usb_endpoint_desc_t depOUT = { .bLength = 7, .bDescriptorType = USB_DESC_ENDPOINT, .bEndpointAddress = 0x02, /* direction OUT */
-	.bmAttributes = 0x02, .wMaxPacketSize = 0x0200, .bInterval = 0
+static const usb_endpoint_desc_t dEpOUT = {
+	.bLength = 7,
+	.bDescriptorType = USB_DESC_ENDPOINT,
+	.bEndpointAddress = 0x02, /* direction OUT */
+	.bmAttributes = 0x02,
+	.wMaxPacketSize = 0x0200,
+	.bInterval = 0
 };
 
 
 /* Data Bulk Endpoint IN */
-static const usb_endpoint_desc_t depIN = { .bLength = 7, .bDescriptorType = USB_DESC_ENDPOINT, .bEndpointAddress = 0x82, /* direction IN */
-	.bmAttributes = 0x02, .wMaxPacketSize = 0x0200, .bInterval = 1
+static const usb_endpoint_desc_t dEpIN = {
+	.bLength = 7,
+	.bDescriptorType = USB_DESC_ENDPOINT,
+	.bEndpointAddress = 0x82, /* direction IN */
+	.bmAttributes = 0x02,
+	.wMaxPacketSize = 0x0200,
+	.bInterval = 1
 };
 
 
-/* String Data */
-static const usb_string_desc_t dstrman = {
-	.bLength = 2 * 18 + 2,
+/* String Data: Manufacturer */
+static const usb_string_desc_t dStrMan = {
+	.bLength = 2 * 15 + 2,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = {	'N', 0, 'X', 0, 'P', 0, ' ', 0, 'S', 0, 'E', 0, 'M', 0, 'I', 0, 'C', 0, 'O', 0, 'N', 0, 'D', 0, 'U', 0, 'C', 0, 'T', 0,
-				'O', 0, 'R', 0, 'S', 0 }
+	.wData = { 'N', 0, 'X', 0, 'P', 0, ' ', 0, 'S', 0, 'E', 0, 'M', 0, 'I', 0, 'C', 0, 'O', 0, 'N', 0, 'D', 0, 'U', 0, 'C', 0, 'T', 0, 'O', 0, 'R', 0, 'S', 0 }
 };
 
 
-static const usb_string_desc_t dstr0 = {
+/* String Data: Language Identifier = 0x0409 (U.S. English) */
+static const usb_string_desc_t dStr0 = {
 	.bLength = 4,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = {0x04, 0x09} /* English */
+	.wData = { 0x09, 0x04 }
 };
 
 
-static const usb_string_desc_t dstrprod = {
-	.bLength = 11 * 2 + 2,
+/* String Data: Product */
+static const usb_string_desc_t dStrProd = {
+	.bLength = 2 * 16 + 2,
 	.bDescriptorType = USB_DESC_STRING,
 	.wData = { 'M', 0, 'C', 0, 'U', 0, ' ', 0, 'V', 0, 'I', 0, 'R', 0, 'T', 0, 'U', 0, 'A', 0, 'L', 0 }
 };
 
 
-int cdc_recv(int endpt, char *data, unsigned int len)
-{
-	return usbclient_receive(endpt, data, len);
-}
-
-
-int cdc_send(int endpt, const char *data, unsigned int len)
-{
-	return usbclient_send(endpt, data, len);
-}
-
-
-void cdc_destroy(void)
-{
-	usbclient_destroy();
-}
-
-
 int cdc_init(void)
 {
-	int res = EOK;
+	cdc_common.descList = NULL;
 
-	cdc_common.dev.descriptor = (usb_functional_desc_t *)&ddev;
+	cdc_common.dev.descriptor = (usb_functional_desc_t *)&dDev;
 	LIST_ADD(&cdc_common.descList, &cdc_common.dev);
 
-	cdc_common.conf.descriptor = (usb_functional_desc_t *)&dconfig;
+	cdc_common.conf.descriptor = (usb_functional_desc_t *)&dConfig;
 	LIST_ADD(&cdc_common.descList, &cdc_common.conf);
 
-	cdc_common.comIface.descriptor = (usb_functional_desc_t *)&dComIntf;
+	cdc_common.comIface.descriptor = (usb_functional_desc_t *)&dComIface;
 	LIST_ADD(&cdc_common.descList, &cdc_common.comIface);
 
 	cdc_common.header.descriptor = (usb_functional_desc_t *)&dHeader;
@@ -169,28 +224,50 @@ int cdc_init(void)
 	cdc_common.comEp.descriptor = (usb_functional_desc_t *)&dComEp;
 	LIST_ADD(&cdc_common.descList, &cdc_common.comEp);
 
-	cdc_common.dataIface.descriptor = (usb_functional_desc_t *)&dDataIntf;
+	cdc_common.dataIface.descriptor = (usb_functional_desc_t *)&dDataIface;
 	LIST_ADD(&cdc_common.descList, &cdc_common.dataIface);
 
-	cdc_common.dataEpOUT.descriptor = (usb_functional_desc_t *)&depOUT;
+	cdc_common.dataEpOUT.descriptor = (usb_functional_desc_t *)&dEpOUT;
 	LIST_ADD(&cdc_common.descList, &cdc_common.dataEpOUT);
 
-	cdc_common.dataEpIN.descriptor = (usb_functional_desc_t *)&depIN;
+	cdc_common.dataEpIN.descriptor = (usb_functional_desc_t *)&dEpIN;
 	LIST_ADD(&cdc_common.descList, &cdc_common.dataEpIN);
 
-	cdc_common.str0.descriptor = (usb_functional_desc_t *)&dstr0;
+	cdc_common.str0.descriptor = (usb_functional_desc_t *)&dStr0;
 	LIST_ADD(&cdc_common.descList, &cdc_common.str0);
 
-	cdc_common.strman.descriptor = (usb_functional_desc_t *)&dstrman;
+	cdc_common.strman.descriptor = (usb_functional_desc_t *)&dStrMan;
 	LIST_ADD(&cdc_common.descList, &cdc_common.strman);
 
-	cdc_common.strprod.descriptor = (usb_functional_desc_t *)&dstrprod;
+	cdc_common.strprod.descriptor = (usb_functional_desc_t *)&dStrProd;
 	LIST_ADD(&cdc_common.descList, &cdc_common.strprod);
 
 	cdc_common.strprod.next = NULL;
 
-	if ((res = usbclient_init(cdc_common.descList)) != EOK)
-		return res;
+	return usbclient_init(cdc_common.descList);
+}
 
-	return res;
+
+void cdc_destroy(void)
+{
+	if (cdc_common.descList != NULL)
+		usbclient_destroy();
+}
+
+
+int cdc_send(int endpt, const char *data, unsigned int len)
+{
+	if (cdc_common.descList != NULL)
+		return usbclient_send(endpt, data, len);
+	else
+		return -ENXIO;
+}
+
+
+int cdc_recv(int endpt, char *data, unsigned int len)
+{
+	if (cdc_common.descList != NULL)
+		return usbclient_receive(endpt, data, len);
+	else
+		return -ENXIO;
 }

--- a/client/cdc_client.h
+++ b/client/cdc_client.h
@@ -21,13 +21,13 @@
 int cdc_init(void);
 
 
-int cdc_recv(int endpt, char *data, unsigned int len);
+void cdc_destroy(void);
 
 
 int cdc_send(int endpt, const char *data, unsigned int len);
 
 
-void cdc_destroy(void);
+int cdc_recv(int endpt, char *data, unsigned int len);
 
 
 #endif

--- a/client/cdc_client.h
+++ b/client/cdc_client.h
@@ -3,8 +3,8 @@
  *
  * cdc - USB Communication Device Class
  *
- * Copyright 2019 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -15,19 +15,53 @@
 #ifndef _CDC_CLIENT_H_
 #define _CDC_CLIENT_H_
 
+
 #include <cdc.h>
 
 
-int cdc_init(void);
+enum {
+	/* CDC Endpoint Types */
+	CDC_ENDPT_CTRL,
+	CDC_ENDPT_IRQ,
+	/* CDC_ACM bulk endpoints are used as IN/OUT pipe communication */
+	CDC_ENDPT_BULK
+};
 
 
+enum {
+	/* CDC Event Types */
+	CDC_EV_DISCONNECT,
+	CDC_EV_CONNECT,
+	CDC_EV_RESET,
+	CDC_EV_INIT,
+	CDC_EV_LINECODING,
+	CDC_EV_CARRIER_ACTIVATE,
+	CDC_EV_CARRIER_DEACTIVATE,
+};
+
+
+/* Initialize CDC device, allocate usb_client resources */
+int cdc_init(void (*cbEvent)(int _evType, void *_ctxUser), void *ctxUser);
+
+
+/* Free CDC device, release usb_client resources */
 void cdc_destroy(void);
 
 
-int cdc_send(int endpt, const char *data, unsigned int len);
+/* Sends data on an given endpoint */
+int cdc_send(int endpt, const void *data, unsigned int len);
 
 
-int cdc_recv(int endpt, char *data, unsigned int len);
+/* Receives data on an given endpoint */
+int cdc_recv(int endpt, void *data, unsigned int len);
+
+
+/* Get current Line Coding information */
+usb_cdc_line_coding_t cdc_getLineCoding(void);
+
+
+/* Set Line Coding information */
+void cdc_setLineCoding(usb_cdc_line_coding_t lineCoding);
 
 
 #endif

--- a/client/hid_client.c
+++ b/client/hid_client.c
@@ -3,8 +3,8 @@
  *
  * hid_client - USB Human Interface Device
  *
- * Copyright 2019 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2019-2021 Phoenix Systems
+ * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -15,9 +15,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <sys/list.h>
-
 #include <usbclient.h>
-
 #include "hid_client.h"
 
 
@@ -39,83 +37,99 @@ struct {
 } hid_common;
 
 
-static const usb_hid_desc_report_t dhidreport = { 2 + 76, USB_DESC_TYPE_HID_REPORT,
-	/* Raw HID report descriptor - compatibile with IMX6ULL SDP protocol */
-	{ 0x06, 0x00, 0xff, 0x09, 0x01, 0xa1, 0x01, 0x85, 0x01, 0x19,
-	  0x01, 0x29, 0x01, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75, 0x08,
-	  0x95, 0x10, 0x91, 0x02, 0x85, 0x02, 0x19, 0x01, 0x29, 0x01,
-	  0x15, 0x00, 0x26, 0xff, 0x00, 0x75, 0x80, 0x95, 0x40, 0x91,
-	  0x02, 0x85, 0x03, 0x19, 0x01, 0x29, 0x01, 0x15, 0x00, 0x26,
-	  0xff, 0x00, 0x75, 0x08, 0x95, 0x04, 0x81, 0x02, 0x85, 0x04,
-	  0x19, 0x01, 0x29, 0x01, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75,
-	  0x08, 0x95, 0x40, 0x81, 0x02, 0xc0 }
+static const usb_hid_desc_report_t dHidReport = {
+	.bLength = 2 + 76,
+	.bType = USB_DESC_TYPE_HID_REPORT,
+	.wData = {
+		/* Raw HID report descriptor - compatibile with IMX6ULL SDP protocol */
+		0x06, 0x00, 0xff, 0x09, 0x01, 0xa1, 0x01, 0x85, 0x01, 0x19,
+		0x01, 0x29, 0x01, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75, 0x08,
+		0x95, 0x10, 0x91, 0x02, 0x85, 0x02, 0x19, 0x01, 0x29, 0x01,
+		0x15, 0x00, 0x26, 0xff, 0x00, 0x75, 0x80, 0x95, 0x40, 0x91,
+		0x02, 0x85, 0x03, 0x19, 0x01, 0x29, 0x01, 0x15, 0x00, 0x26,
+		0xff, 0x00, 0x75, 0x08, 0x95, 0x04, 0x81, 0x02, 0x85, 0x04,
+		0x19, 0x01, 0x29, 0x01, 0x15, 0x00, 0x26, 0xff, 0x00, 0x75,
+		0x08, 0x95, 0x40, 0x81, 0x02, 0xc0 }
 };
 
 
-static const usb_endpoint_desc_t dep = { .bLength = 7, .bDescriptorType = USB_DESC_ENDPOINT, .bEndpointAddress = 0x81, /* direction IN */
-	.bmAttributes = 0x03, .wMaxPacketSize = 64, .bInterval = 0x01
+static const usb_endpoint_desc_t dEp = {
+	.bLength = 7,
+	.bDescriptorType = USB_DESC_ENDPOINT,
+	.bEndpointAddress = 0x81, /* direction IN */
+	.bmAttributes = 0x03,
+	.wMaxPacketSize = 64,
+	.bInterval = 0x01
 };
 
 
-static const usb_hid_desc_t dhid = { 9, USB_DESC_TYPE_HID, 0x0110, 0x0, 1, 0x22, 76 };
-
-
-static const usb_interface_desc_t diface = { .bLength = 9, .bDescriptorType = USB_DESC_INTERFACE, .bInterfaceNumber = 0, .bAlternateSetting = 0,
-	.bNumEndpoints = 1, .bInterfaceClass = 0x03, .bInterfaceSubClass = 0x00, .bInterfaceProtocol = 0x00, .iInterface = 2
+/* USB HID Descriptor */
+static const usb_hid_desc_t dHid = {
+	.bLength = 9,
+	.bType = USB_DESC_TYPE_HID,
+	.bcdHID = 0x0110,
+	.bCountryCode = 0x00,
+	.bNumDescriptors = 1,
+	.bDescriptorType = 0x22,
+	.wDescriptorLength = 76
 };
 
 
-static const usb_configuration_desc_t dconfig = { .bLength = 9, .bDescriptorType = USB_DESC_CONFIG,
-	.wTotalLength = sizeof(usb_configuration_desc_t) + sizeof(usb_interface_desc_t) + sizeof(dhid) + sizeof(usb_endpoint_desc_t),
-	.bNumInterfaces = 1, .bConfigurationValue = 1, .iConfiguration = 1, .bmAttributes = 0xc0, .bMaxPower = 5
+/* Interface Descriptor */
+static const usb_interface_desc_t dIface = {
+	.bLength = 9,
+	.bDescriptorType = USB_DESC_INTERFACE,
+	.bInterfaceNumber = 0,
+	.bAlternateSetting = 0,
+	.bNumEndpoints = 1,
+	.bInterfaceClass = 0x03,
+	.bInterfaceSubClass = 0x00,
+	.bInterfaceProtocol = 0x00,
+	.iInterface = 2
 };
 
 
-static const usb_string_desc_t dstr0 = {
+/* Configuration descriptor */
+static const usb_configuration_desc_t dConfig = {
+	.bLength = 9,
+	.bDescriptorType = USB_DESC_CONFIG,
+	.wTotalLength = sizeof(usb_configuration_desc_t) + sizeof(usb_interface_desc_t) + sizeof(dHid) + sizeof(usb_endpoint_desc_t),
+	.bNumInterfaces = 1,
+	.bConfigurationValue = 1,
+	.iConfiguration = 1,
+	.bmAttributes = 0xc0,
+	.bMaxPower = 5
+};
+
+
+/* String Data: Language Identifier = 0x0409 (U.S. English) */
+static const usb_string_desc_t dStr0 = {
 	.bLength = 4,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = {0x04, 0x09} /* English */
+	.wData = { 0x09, 0x04 }
 };
-
-
-int hid_recv(int endpt, char *data, unsigned int len)
-{
-	return usbclient_receive(endpt, data, len);
-}
-
-
-int hid_send(int endpt, const char *data, unsigned int len)
-{
-	return usbclient_send(endpt, data, len);
-}
-
-
-void hid_destroy(void)
-{
-	usbclient_destroy();
-}
 
 
 int hid_init(const usb_hid_dev_setup_t *dev_setup)
 {
-	int res = EOK;
+	hid_common.descList = NULL;
 
 	hid_common.dev.descriptor = (usb_functional_desc_t *)&dev_setup->dDevice;
 	LIST_ADD(&hid_common.descList, (usb_desc_list_t *)&hid_common.dev);
 
-	hid_common.conf.descriptor = (usb_functional_desc_t *)&dconfig;
+	hid_common.conf.descriptor = (usb_functional_desc_t *)&dConfig;
 	LIST_ADD(&hid_common.descList, (usb_desc_list_t *)&hid_common.conf);
 
-	hid_common.iface.descriptor = (usb_functional_desc_t *)&diface;
+	hid_common.iface.descriptor = (usb_functional_desc_t *)&dIface;
 	LIST_ADD(&hid_common.descList, &hid_common.iface);
 
-	hid_common.hid.descriptor = (usb_functional_desc_t *)&dhid;
+	hid_common.hid.descriptor = (usb_functional_desc_t *)&dHid;
 	LIST_ADD(&hid_common.descList, &hid_common.hid);
 
-	hid_common.ep.descriptor = (usb_functional_desc_t *)&dep;
+	hid_common.ep.descriptor = (usb_functional_desc_t *)&dEp;
 	LIST_ADD(&hid_common.descList, &hid_common.ep);
 
-	hid_common.str0.descriptor = (usb_functional_desc_t *)&dstr0;
+	hid_common.str0.descriptor = (usb_functional_desc_t *)&dStr0;
 	LIST_ADD(&hid_common.descList, &hid_common.str0);
 
 	hid_common.strman.descriptor = (usb_functional_desc_t *)&dev_setup->dStrMan;
@@ -124,13 +138,35 @@ int hid_init(const usb_hid_dev_setup_t *dev_setup)
 	hid_common.strprod.descriptor = (usb_functional_desc_t *)&dev_setup->dStrProd;
 	LIST_ADD(&hid_common.descList, &hid_common.strprod);
 
-	hid_common.hidreport.descriptor = (usb_functional_desc_t *)&dhidreport;
+	hid_common.hidreport.descriptor = (usb_functional_desc_t *)&dHidReport;
 	LIST_ADD(&hid_common.descList, &hid_common.hidreport);
 
 	hid_common.hidreport.next = NULL;
 
-	if ((res = usbclient_init(hid_common.descList)) != EOK)
-		return res;
+	return usbclient_init(hid_common.descList);
+}
 
-	return res;
+
+void hid_destroy(void)
+{
+	if (hid_common.descList != NULL)
+		usbclient_destroy();
+}
+
+
+int hid_send(int endpt, const char *data, unsigned int len)
+{
+	if (hid_common.descList != NULL)
+		return usbclient_send(endpt, data, len);
+	else
+		return -ENXIO;
+}
+
+
+int hid_recv(int endpt, char *data, unsigned int len)
+{
+	if (hid_common.descList != NULL)
+		return usbclient_receive(endpt, data, len);
+	else
+		return -ENXIO;
 }

--- a/client/hid_client.h
+++ b/client/hid_client.h
@@ -19,16 +19,27 @@
 #include <hid.h>
 
 
+enum {
+	/* HID Endpoint Types */
+	HID_ENDPT_CTRL,
+	HID_ENDPT_IRQ,
+};
+
+
+/* Initialize HID device */
 int hid_init(const usb_hid_dev_setup_t* dev_setup);
 
 
+/* Free resources used by HID device */
 void hid_destroy(void);
 
 
-int hid_send(int endpt, const char *data, unsigned int len);
+/* Sends HID data on an given endpoint */
+int hid_send(int endpt, const void *data, unsigned int len);
 
 
-int hid_recv(int endpt, char *data, unsigned int len);
+/* Receives HID data on an given endpoint */
+int hid_recv(int endpt, void *data, unsigned int len);
 
 
 #endif

--- a/client/hid_client.h
+++ b/client/hid_client.h
@@ -19,16 +19,16 @@
 #include <hid.h>
 
 
-int hid_send(int endpt, const char *data, unsigned int len);
-
-
-int hid_recv(int endpt, char *data, unsigned int len);
-
-
 int hid_init(const usb_hid_dev_setup_t* dev_setup);
 
 
 void hid_destroy(void);
+
+
+int hid_send(int endpt, const char *data, unsigned int len);
+
+
+int hid_recv(int endpt, char *data, unsigned int len);
 
 
 #endif

--- a/common/Makefile
+++ b/common/Makefile
@@ -1,7 +1,7 @@
 #
 # Makefile for Phoenix-RTOS hid and cdc API
 #
-# Copyright 2020 Phoenix Systems
+# Copyright 2020-2021 Phoenix Systems
 #
 
 

--- a/common/hid.h
+++ b/common/hid.h
@@ -46,4 +46,5 @@ typedef struct _usb_hid_desc_t {
 	uint16_t wDescriptorLength;
 } __attribute__((packed)) usb_hid_desc_t;
 
+
 #endif

--- a/drivers/cdc_demo_client/cdc_demo.c
+++ b/drivers/cdc_demo_client/cdc_demo.c
@@ -3,8 +3,8 @@
  *
  * cdc demo - Example of using: USB Communication Device Class
  *
- * Copyright 2019 Phoenix Systems
- * Author: Hubert Buczynski
+ * Copyright 2019, 2021 Phoenix Systems
+ * Author: Hubert Buczynski, Gerard Swiderski
  *
  * This file is part of Phoenix-RTOS.
  *
@@ -12,62 +12,233 @@
  */
 
 
-#include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
-
-#include <sys/platform.h>
-#include <phoenix/arch/imxrt.h>
-
 #include <cdc_client.h>
 
-#define RCV_MODE 2
-#define SENDING_MODE 1
 
-#define CDC_MODE RCV_MODE
+#define TIME_ONESECOND              1000000000ULL
+#define TIME_REALTIME_OVERFLOW      (TIME_ONESECOND / 5)
 
-#define BUFF_SIZE 0x1000
+#define USB_BUF_SIZE                0x1000
 
-#define LOG(str, ...) do { if (1) fprintf(stderr, "cdc-client: " str "\n", ##__VA_ARGS__); } while (0)
-#define LOG_ERROR(str, ...) do { fprintf(stderr, __FILE__  ":%d error: " str "\n", __LINE__, ##__VA_ARGS__); } while (0)
+#define LOG(str, ...)               do { if (1) fprintf(stderr, "cdc-demo: " str "\n", ##__VA_ARGS__); } while (0)
+#define LOG_ERROR(str, ...)         do { fprintf(stderr, __FILE__  ":%d error: " str "\n", __LINE__, ##__VA_ARGS__); } while (0)
 
 
-struct {
-	char buff[BUFF_SIZE];
-} client_common;
+static const char animHourGlass[] = { '/', '|', '\\', '-' };
+
+
+typedef struct {
+	struct {
+		void *ptr;
+		size_t size;
+	} buf;
+
+	struct {
+		unsigned int steps;
+		uint64_t current;
+		uint64_t schedule;
+		uint64_t start;
+	} time;
+
+	struct {
+		size_t totalTransfered;
+	} stat;
+
+	struct {
+		uint8_t isQuit : 1; /* TODO: attach to SIGQUIT signal  */
+		uint8_t isConnected : 1;
+		uint8_t canPushData : 1;
+		uint8_t isDrop : 1;
+	} flags;
+} cdc_demo_ctx_t;
+
+
+static uint64_t getTimeStamp(void)
+{
+	struct timespec t1;
+	clock_gettime(CLOCK_MONOTONIC, &t1);
+
+	return (uint64_t)t1.tv_sec * TIME_ONESECOND + t1.tv_nsec;
+}
+
+
+static void cdc_demoEventNotify(int evType, void *ctxUser)
+{
+	cdc_demo_ctx_t *ctx = (cdc_demo_ctx_t *)ctxUser;
+
+	switch (evType) {
+		case CDC_EV_RESET:
+		case CDC_EV_DISCONNECT:
+			ctx->flags.canPushData = 0;
+			ctx->flags.isConnected = 0;
+			break;
+
+		case CDC_EV_CONNECT:
+			ctx->flags.isConnected = 1;
+			break;
+
+		case CDC_EV_CARRIER_DEACTIVATE:
+			ctx->flags.canPushData = 0;
+			break;
+
+		case CDC_EV_CARRIER_ACTIVATE:
+			if (ctx->flags.isConnected) {
+				ctx->stat.totalTransfered = 0;
+				ctx->flags.isDrop = 1;
+				ctx->flags.canPushData = 1;
+			}
+			break;
+	}
+}
+
+
+static void cdc_demoProgress(cdc_demo_ctx_t *ctx)
+{
+
+	if (ctx->flags.canPushData) {
+		uint32_t delta = ctx->time.current > ctx->time.start
+			? (ctx->time.current - ctx->time.start) / TIME_ONESECOND
+			: ctx->stat.totalTransfered;
+
+		ctx->time.schedule += TIME_ONESECOND;
+
+		printf("\rTotal %u bytes transfered at %u kB/s\033[0J", ctx->stat.totalTransfered, ctx->stat.totalTransfered / (delta * 1000));
+	}
+	else {
+		ctx->time.schedule += TIME_ONESECOND / 4;
+
+		printf("\rIdle %c (%s host)\033[0J",
+				animHourGlass[ctx->time.steps % sizeof(animHourGlass)], ctx->flags.isConnected ? "connected to" : "disconnected from");
+	}
+
+	fflush(stdout);
+}
+
+
+static void cdc_demoPepareData(cdc_demo_ctx_t *ctx)
+{
+	unsigned int n;
+	uint8_t *buf = (uint8_t *)ctx->buf.ptr;
+
+	if (ctx->flags.isDrop) {
+		ctx->flags.isDrop = 0;
+		/* send block of zeros - mark droped real time data */
+		bzero(ctx->buf.ptr, ctx->buf.size);
+	}
+	else {
+		for (n = 0; n < ctx->buf.size; n++)
+			*buf++ = ' ' + n % ('~' - ' ');
+	}
+}
+
+
+static void cdc_demoSend(cdc_demo_ctx_t *ctx)
+{
+	int res = cdc_send(CDC_ENDPT_BULK, ctx->buf.ptr, ctx->buf.size);
+	uint64_t delayed;
+
+	if (res < 0) {
+		LOG("cdc_send(): failed");
+		ctx->flags.isDrop = 1;
+		return;
+	}
+
+	delayed = getTimeStamp() - ctx->time.current;
+	if (delayed > TIME_REALTIME_OVERFLOW) {
+		LOG("cdc_send(): blocked for too long, dropping all realtime data!");
+		ctx->flags.isDrop = 1;
+		return;
+	}
+
+	ctx->stat.totalTransfered += res;
+}
+
+
+static void cdc_demoRecv(cdc_demo_ctx_t *ctx)
+{
+	int res = cdc_recv(CDC_ENDPT_BULK, ctx->buf.ptr, ctx->buf.size);
+
+	if (res < 0) {
+		LOG("cdc_recv(): failed");
+		ctx->flags.isDrop = 1;
+		return;
+	}
+
+	ctx->stat.totalTransfered += res;
+}
 
 
 int main(int argc, char **argv)
 {
+	cdc_demo_ctx_t ctx = { .buf = { .size = USB_BUF_SIZE } };
+	int modeRecv = argc > 1 && (*argv[1] | 0x20) == 'r';
+
+	/*
+	 * pass r or R in program args to start receiving mode
+	 */
+
 	sleep(1);
 
 	LOG("started.");
 
-	if (cdc_init(NULL, NULL)) {
-		LOG_ERROR("couldn't initialize CDC transport.");
+	if ((ctx.buf.ptr = malloc(ctx.buf.size)) == NULL) {
+		LOG_ERROR("Out of memory.");
 		return -1;
 	}
 
-	LOG("initialized.");
+	if (cdc_init(cdc_demoEventNotify, &ctx)) {
+		free(ctx.buf.ptr);
+		LOG_ERROR("couldn't initialize CDC transport.");
+		return -2;
+	}
 
-#if CDC_MODE == SENDING_MODE
-	int i;
-	for (i = 0; i < BUFF_SIZE; i++)
-		client_common.buff[i] = 'A' + i % ('Z' - 'A');
+	if (modeRecv)
+		LOG("initialized in receiving mode");
+	else
+		LOG("initialized in sending mode");
 
-	LOG("SENDING MODE initialized.");
-	while (1)
-		cdc_send(CDC_ENDPT_BULK, (char *)client_common.buff, BUFF_SIZE);
-#elif CDC_MODE == RCV_MODE
-	LOG("RCV MODE initialized.");
+	ctx.time.start = getTimeStamp();
 
-	while (1)
-		printf("Size: %d\n", cdc_recv(ENDPOINT_BULK, (char *)client_common.buff, BUFF_SIZE));
-#else
-	while (1)
-	{}
-#endif
+	while (ctx.flags.isQuit == 0) {
+		ctx.time.current = getTimeStamp();
 
-	return EOK;
+		if (ctx.time.schedule < ctx.time.current) {
+			ctx.time.steps++;
+			cdc_demoProgress(&ctx);
+		}
+
+		if (ctx.flags.canPushData == 0) {
+			/* idle */
+			ctx.time.start = ctx.time.current;
+			usleep(200 * 1000);
+			continue;
+		}
+
+		if (modeRecv) {
+			cdc_demoRecv(&ctx);
+		}
+		else {
+			cdc_demoPepareData(&ctx);
+			cdc_demoSend(&ctx);
+		}
+
+		/*
+		 * the below usleep/yield is not necessary when speed of 22MB/s (~180Mbit/s)
+		 * is required but it may flood hub and other devices like mouse, keyboard
+		 * may freeze :), when usleep(1) is used data transfer drops to 6MB/s (~50Mbit),
+		 * test it yourself (50MB/s ~400Mbit/s may be achieved by removing any hub
+		 * in between device and PC, und usleep(1) below.
+		 */
+		usleep(1);
+	}
+
+	cdc_destroy();
+	free(ctx.buf.ptr);
+
+	return 0;
 }

--- a/drivers/cdc_demo_client/cdc_demo.c
+++ b/drivers/cdc_demo_client/cdc_demo.c
@@ -39,22 +39,9 @@ struct {
 } client_common;
 
 
-static void cdc_enabelCache(unsigned char enable)
-{
-	platformctl_t pctl;
-
-	pctl.action = pctl_set;
-	pctl.type = pctl_devcache;
-	pctl.devcache.state = !!enable;
-
-	platformctl(&pctl);
-}
-
-
 int main(int argc, char **argv)
 {
 	sleep(1);
-	cdc_enabelCache(0);
 
 	LOG("started.");
 
@@ -62,6 +49,8 @@ int main(int argc, char **argv)
 		LOG_ERROR("couldn't initialize CDC transport.");
 		return -1;
 	}
+
+	LOG("initialized.");
 
 #if CDC_MODE == SENDING_MODE
 	int i;

--- a/drivers/cdc_demo_client/cdc_demo.c
+++ b/drivers/cdc_demo_client/cdc_demo.c
@@ -27,7 +27,6 @@
 
 #define CDC_MODE RCV_MODE
 
-#define ENDPOINT_BULK 2
 #define BUFF_SIZE 0x1000
 
 #define LOG(str, ...) do { if (1) fprintf(stderr, "cdc-client: " str "\n", ##__VA_ARGS__); } while (0)
@@ -45,7 +44,7 @@ int main(int argc, char **argv)
 
 	LOG("started.");
 
-	if (cdc_init()) {
+	if (cdc_init(NULL, NULL)) {
 		LOG_ERROR("couldn't initialize CDC transport.");
 		return -1;
 	}
@@ -59,7 +58,7 @@ int main(int argc, char **argv)
 
 	LOG("SENDING MODE initialized.");
 	while (1)
-		cdc_send(ENDPOINT_BULK, (char *)client_common.buff, BUFF_SIZE);
+		cdc_send(CDC_ENDPT_BULK, (char *)client_common.buff, BUFF_SIZE);
 #elif CDC_MODE == RCV_MODE
 	LOG("RCV MODE initialized.");
 


### PR DESCRIPTION
With change (https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/82) disabling cache, system wide, is no more required to launch `cdc_demo` because `usbclient `now works with `DTCM` memory region.

Added:
- basic event and notification handling (connected, disconnected, reset, class setup, etc)
- class setup was moved from desc_manager to CDC and HID client respectively.