### PR TITLE
usb: fix TT bugs and class-specific functional descriptor discovery

### DIFF
--- a/libusb/include/usb.h
+++ b/libusb/include/usb.h
@@ -197,6 +197,13 @@ typedef struct {
 /* generic descriptor
  * used when there is no defined descriptor (e.g. HID descriptor or Report descriptor) */
 typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t wData[];
+} __attribute__((packed)) usb_generic_desc_t;
+
+
+typedef struct {
 	uint8_t bFunctionLength;
 	uint8_t bDescriptorType;
 	uint8_t bDescriptorSubtype;

--- a/usb/dev.c
+++ b/usb/dev.c
@@ -262,7 +262,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 		uint8_t len = ((struct usb_desc_header *)ptr)->bLength;
 
 		if ((len < sizeof(struct usb_desc_header)) || (len > size)) {
-			log_error("Invalid descriptor size: %u\n", len);
+			log_error("Invalid descriptor size: %u", len);
 			break;
 		}
 
@@ -286,7 +286,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 					}
 				}
 				else {
-					log_error("Interface descriptor with invalid size\n");
+					log_error("Interface descriptor with invalid size");
 					ret = -1;
 				}
 				break;
@@ -314,7 +314,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 					}
 				}
 				else {
-					log_error("Endpoint descriptor with invalid size\n");
+					log_error("Endpoint descriptor with invalid size");
 					ret = -1;
 				}
 				break;
@@ -327,17 +327,19 @@ static int usb_getConfiguration(usb_dev_t *dev)
 					dev->desc.bDeviceProtocol = ((usb_interface_association_desc_t *)ptr)->bFunctionProtocol;
 				}
 				else {
-					log_error("Interface assoctiation descriptor with invalid size\n");
+					log_error("Interface association descriptor with invalid size");
 					ret = -1;
 				}
 				break;
 
-			case USB_DESC_CS_INTERFACE:
-				/* TODO: save Class-Specific Functional Descriptors to be used by device drivers - silently ignored for now */
-				break;
-
 			default:
-				log_error("Ignoring unkonown descriptor type: 0x%02x\n", ((struct usb_desc_header *)ptr)->bDescriptorType);
+				/* assume unknown descriptor type is a class-specific or vendor-specific functional descriptor */
+				if (lastAlternateSetting != 0) {
+					/* TODO: handle alternate setting maybe */
+				}
+				else if (lastIfNum >= 0) {
+					dev->ifs[lastIfNum].func = (usb_generic_desc_t *)ptr;
+				}
 				break;
 		}
 
@@ -346,7 +348,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 	}
 
 	for (size_t i = 0; i < dev->nifs; i++) {
-		if ((dev->ifs[i].desc == NULL) || (dev->ifs[i].eps == NULL)) {
+		if ((dev->ifs[i].desc == NULL) || ((dev->ifs[i].eps == NULL) && (dev->ifs[i].func == NULL))) {
 			/* Data missing */
 			ret = -1;
 			break;

--- a/usb/dev.c
+++ b/usb/dev.c
@@ -679,7 +679,6 @@ int usb_devEnumerate(usb_dev_t *dev)
 	else if (usb_drvBind(dev, usb_devOnDrvBindCb) != 0) {
 		log_msg("Fail to match drivers for device\n");
 		/* TODO: make device orphaned */
-		return -1;
 	}
 
 	return 0;

--- a/usb/dev.h
+++ b/usb/dev.h
@@ -35,6 +35,7 @@ typedef struct {
 typedef struct {
 	usb_interface_desc_t *desc;
 	usb_endpoint_desc_t *eps;
+	usb_generic_desc_t *func;
 	void *classDesc;
 	usb_lenStr_t name;
 

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -43,6 +43,10 @@
 #undef USB_LOG_TAG
 #define USB_LOG_TAG "usbhub"
 
+#ifndef USB_HUB_TT_WORKAROUND
+#define USB_HUB_TT_WORKAROUND 0
+#endif
+
 
 typedef struct _hub_event {
 	struct _hub_event *next, *prev;
@@ -177,13 +181,6 @@ static int hub_interruptInit(usb_dev_t *hub)
 }
 
 
-static int hub_isTT(usb_dev_t *dev)
-{
-	/* TODO support MTTs */
-	return dev->desc.bDeviceClass == USB_CLASS_HUB && dev->desc.bDeviceProtocol == USB_HUB_PROTO_SINGLE_TT;
-}
-
-
 static int hub_requestStatus(usb_dev_t *hub)
 {
 	return usb_transferSubmit(hub->statusTransfer, hub->irqPipe, NULL);
@@ -262,6 +259,14 @@ static int hub_portDebounce(usb_dev_t *hub, int port)
 }
 
 
+#if USB_HUB_TT_WORKAROUND
+static int hub_isTT(usb_dev_t *dev)
+{
+	/* TODO support MTTs */
+	return dev->desc.bDeviceClass == USB_CLASS_HUB && dev->desc.bDeviceProtocol == USB_HUB_PROTO_SINGLE_TT;
+}
+
+
 static void hub_ttAdd(usb_dev_t *hub)
 {
 	mutexLock(hub_common.lock);
@@ -276,14 +281,17 @@ static void hub_ttRemove(usb_dev_t *hub)
 	LIST_REMOVE(&hub_common.tts, hub);
 	mutexUnlock(hub_common.lock);
 }
+#endif
 
 
 static void hub_devDisconnect(usb_dev_t *dev, bool silent)
 {
-	usb_devDisconnected(dev, silent);
+#if USB_HUB_TT_WORKAROUND
 	if (hub_isTT(dev)) {
 		hub_ttRemove(dev);
 	}
+#endif
+	usb_devDisconnected(dev, silent);
 }
 
 
@@ -399,6 +407,7 @@ static uint32_t hub_getStatus(usb_dev_t *hub)
 }
 
 
+#if USB_HUB_TT_WORKAROUND
 static void hub_ttStatus(void)
 {
 	usb_dev_t *hub;
@@ -415,6 +424,7 @@ static void hub_ttStatus(void)
 		}
 	} while ((hub = hub->next) != hub_common.tts);
 }
+#endif
 
 
 static void hub_thread(void *args)
@@ -426,6 +436,7 @@ static void hub_thread(void *args)
 	for (;;) {
 		mutexLock(hub_common.lock);
 		while (hub_common.events == NULL) {
+#if USB_HUB_TT_WORKAROUND
 			condWait(hub_common.cond, hub_common.lock, HUB_TT_POLL_DELAY_MS);
 
 			/*
@@ -437,6 +448,9 @@ static void hub_thread(void *args)
 			mutexUnlock(hub_common.lock);
 			hub_ttStatus();
 			mutexLock(hub_common.lock);
+#else
+			condWait(hub_common.cond, hub_common.lock, 0);
+#endif
 		}
 		ev = hub_common.events;
 		LIST_REMOVE(&hub_common.events, ev);
@@ -504,14 +518,16 @@ int hub_conf(usb_dev_t *hub)
 	if (hub_interruptInit(hub) != 0)
 		return -EINVAL;
 
+#if USB_HUB_TT_WORKAROUND
 	if (hub_isTT(hub)) {
-		// FIXME Interrupt pipe notifications from tier 2 TTs never come, which is
-		// either a quirk in currently tested hw or an issue in the hcd driver
-
-		// In addition to request an interrupt request, actively poll the status as well
-		// for as a workaround
+		/*
+		 * FIXME Interrupt pipe notifications from tier 2 TTs never come on ia32,
+		 * which is either a quirk in currently tested hw or an issue in the hcd driver.
+		 * As a workaround, try to receive interrupt requests AND actively poll the status.
+		 */
 		hub_ttAdd(hub);
 	}
+#endif
 
 	return hub_requestStatus(hub);
 }

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -37,16 +37,10 @@
 #define HUB_DEBOUNCE_STABLE  100000
 #define HUB_DEBOUNCE_PERIOD  25000
 #define HUB_DEBOUNCE_TIMEOUT 1500000
-#define HUB_TT_POLL_DELAY_MS 1000000
 
 
 #undef USB_LOG_TAG
 #define USB_LOG_TAG "usbhub"
-
-#ifndef USB_HUB_TT_WORKAROUND
-#define USB_HUB_TT_WORKAROUND 0
-#endif
-
 
 typedef struct _hub_event {
 	struct _hub_event *next, *prev;
@@ -259,38 +253,8 @@ static int hub_portDebounce(usb_dev_t *hub, int port)
 }
 
 
-#if USB_HUB_TT_WORKAROUND
-static int hub_isTT(usb_dev_t *dev)
-{
-	/* TODO support MTTs */
-	return dev->desc.bDeviceClass == USB_CLASS_HUB && dev->desc.bDeviceProtocol == USB_HUB_PROTO_SINGLE_TT;
-}
-
-
-static void hub_ttAdd(usb_dev_t *hub)
-{
-	mutexLock(hub_common.lock);
-	LIST_ADD(&hub_common.tts, hub);
-	mutexUnlock(hub_common.lock);
-}
-
-
-static void hub_ttRemove(usb_dev_t *hub)
-{
-	mutexLock(hub_common.lock);
-	LIST_REMOVE(&hub_common.tts, hub);
-	mutexUnlock(hub_common.lock);
-}
-#endif
-
-
 static void hub_devDisconnect(usb_dev_t *dev, bool silent)
 {
-#if USB_HUB_TT_WORKAROUND
-	if (hub_isTT(dev)) {
-		hub_ttRemove(dev);
-	}
-#endif
 	usb_devDisconnected(dev, silent);
 }
 
@@ -407,26 +371,6 @@ static uint32_t hub_getStatus(usb_dev_t *hub)
 }
 
 
-#if USB_HUB_TT_WORKAROUND
-static void hub_ttStatus(void)
-{
-	usb_dev_t *hub;
-	int i;
-
-	hub = hub_common.tts;
-	if (hub == NULL) {
-		return;
-	}
-
-	do {
-		for (i = 0; i < hub->nports; i++) {
-			hub_portstatus(hub, i + 1);
-		}
-	} while ((hub = hub->next) != hub_common.tts);
-}
-#endif
-
-
 static void hub_thread(void *args)
 {
 	hub_event_t *ev;
@@ -436,21 +380,7 @@ static void hub_thread(void *args)
 	for (;;) {
 		mutexLock(hub_common.lock);
 		while (hub_common.events == NULL) {
-#if USB_HUB_TT_WORKAROUND
-			condWait(hub_common.cond, hub_common.lock, HUB_TT_POLL_DELAY_MS);
-
-			/*
-			 * hub_ttStatus may lead to usb_devEnumerate call which may call hub_conf that
-			 * tries to obtain this lock. FIXME? It may be better to separate the enumeration
-			 * from the connect status polling logic, but as this polling loop is a
-			 * part of L2 TT workaround, the problem may be easier to solve itself in the root
-			 */
-			mutexUnlock(hub_common.lock);
-			hub_ttStatus();
-			mutexLock(hub_common.lock);
-#else
 			condWait(hub_common.cond, hub_common.lock, 0);
-#endif
 		}
 		ev = hub_common.events;
 		LIST_REMOVE(&hub_common.events, ev);
@@ -517,17 +447,6 @@ int hub_conf(usb_dev_t *hub)
 
 	if (hub_interruptInit(hub) != 0)
 		return -EINVAL;
-
-#if USB_HUB_TT_WORKAROUND
-	if (hub_isTT(hub)) {
-		/*
-		 * FIXME Interrupt pipe notifications from tier 2 TTs never come on ia32,
-		 * which is either a quirk in currently tested hw or an issue in the hcd driver.
-		 * As a workaround, try to receive interrupt requests AND actively poll the status.
-		 */
-		hub_ttAdd(hub);
-	}
-#endif
 
 	return hub_requestStatus(hub);
 }

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -427,7 +427,16 @@ static void hub_thread(void *args)
 		mutexLock(hub_common.lock);
 		while (hub_common.events == NULL) {
 			condWait(hub_common.cond, hub_common.lock, HUB_TT_POLL_DELAY_MS);
+
+			/*
+			 * hub_ttStatus may lead to usb_devEnumerate call which may call hub_conf that
+			 * tries to obtain this lock. FIXME? It may be better to separate the enumeration
+			 * from the connect status polling logic, but as this polling loop is a
+			 * part of L2 TT workaround, the problem may be easier to solve itself in the root
+			 */
+			mutexUnlock(hub_common.lock);
 			hub_ttStatus();
+			mutexLock(hub_common.lock);
 		}
 		ev = hub_common.events;
 		LIST_REMOVE(&hub_common.events, ev);


### PR DESCRIPTION
JIRA: RTOS-1121

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

Various bug fixes that came up when probing the CYW4373E dongle composed of a TT hub and 3 internal devices, some of which contained class-specific functional descriptors that were incorrectly parsed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These changes make it possible to run the CYW4373E driver (https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/596).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [X] Tested by hand on: nilee

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
