### PR TITLE
!libusb/procdriver: accept prio and nthreads as usb_driverProcRun args

### DIFF
--- a/libusb/include/usbprocdriver.h
+++ b/libusb/include/usbprocdriver.h
@@ -18,7 +18,12 @@
 #include <usbdriver.h>
 
 
-int usb_driverProcRun(usb_driver_t *driver, void *args);
+/*
+ * Initializes the given driver and spawns a thread pool of nthreads of prio priority to handle usbhost events.
+ * Threads concurrently process insertion/deletion/completion events with provided driver->handlers. Calls exit(1)
+ * on any failure.
+ */
+__attribute__((noreturn)) void usb_driverProcRun(usb_driver_t *driver, unsigned int prio, unsigned int nthreads, void *args);
 
 
 #endif

--- a/libusb/procdriver.c
+++ b/libusb/procdriver.c
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <sys/msg.h>
+#include <sys/mman.h>
 #include <sys/threads.h>
 #include <sys/list.h>
 #include <string.h>
@@ -24,30 +25,24 @@
 #include "log.h"
 
 
-#ifndef USB_N_UMSG_THREADS
-#define USB_N_UMSG_THREADS 2
-#endif
-
-#ifndef USB_UMSG_PRIO
-#define USB_UMSG_PRIO 3
-#endif
-
-
 #undef LIBUSB_LOG_TAG
 #define LIBUSB_LOG_TAG "libusb(procdriver)"
+
+#ifndef USB_UMSG_STACKSIZE
+#define USB_UMSG_STACKSIZE 2048
+#endif
 
 
 static usb_pipeOps_t usbprocdrv_pipeOps;
 
 
 static struct {
-	char ustack[USB_N_UMSG_THREADS - 1][2048] __attribute__((aligned(8)));
 	unsigned srvport;
 	unsigned drvport;
 } usbprocdrv_common;
 
 
-static void usb_thread(void *arg)
+__attribute__((noreturn)) static void usb_thread(void *arg)
 {
 	usb_driver_t *drv = (usb_driver_t *)arg;
 	msg_t msg = { 0 };
@@ -111,17 +106,19 @@ static int usb_connect(usb_driver_t *drv)
 }
 
 
-int usb_driverProcRun(usb_driver_t *drv, void *args)
+__attribute__((noreturn)) void usb_driverProcRun(usb_driver_t *drv, unsigned int prio, unsigned int nthreads, void *args)
 {
 	oid_t oid;
 	int ret, i;
+	void *stack;
 
 	/* usb_driverProcRun is invoked iff drivers are in the proc variant */
 	drv->pipeOps = &usbprocdrv_pipeOps;
 
 	ret = drv->ops.init(drv, args);
 	if (ret < 0) {
-		return -1;
+		log_error("%s: failed to initialize the driver [%d]", drv->name, ret);
+		exit(1);
 	}
 
 	usb_hostLookup(&oid);
@@ -129,26 +126,32 @@ int usb_driverProcRun(usb_driver_t *drv, void *args)
 
 	ret = portCreate(&usbprocdrv_common.drvport);
 	if (ret != 0) {
-		return -1;
+		log_error("%s: failed to create port [%d]", drv->name, ret);
+		exit(1);
 	}
 
 	ret = usb_connect(drv);
 	if (ret < 0) {
-		return -1;
+		log_error("%s: failed to connect to usbhost [%d]", drv->name, ret);
+		exit(1);
 	}
 
-	for (i = 0; i < USB_N_UMSG_THREADS - 1; i++) {
-		ret = beginthread(usb_thread, USB_UMSG_PRIO, usbprocdrv_common.ustack[i], sizeof(usbprocdrv_common.ustack[i]), drv);
+	for (i = 0; i + 1 < nthreads; i++) {
+		stack = mmap(NULL, USB_UMSG_STACKSIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (stack == MAP_FAILED) {
+			log_error("%s: mmap failed", drv->name);
+			exit(1);
+		}
+
+		ret = beginthread(usb_thread, prio, stack, USB_UMSG_STACKSIZE, drv);
 		if (ret < 0) {
-			log_error("fail to beginthread ret: %d\n", ret);
-			return -1;
+			log_error("%s: failed to start thread [%d]\n", drv->name, ret);
+			exit(1);
 		}
 	}
 
-	priority(USB_UMSG_PRIO);
+	priority(prio);
 	usb_thread(drv);
-
-	return 0;
 }
 
 


### PR DESCRIPTION
JIRA: RTOS-1214

Breaking change: changes `usb_driverProcRun` signature to accept `prio` and `nthreads` as arguments

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
