### PR TITLE
libusb/cdc_client: allow setting custom product name

### DIFF
--- a/libusb/cdc_client.c
+++ b/libusb/cdc_client.c
@@ -17,7 +17,39 @@
 #include <string.h>
 #include <sys/list.h>
 #include <usbclient.h>
+#include <board_config.h>
 #include "cdc_client.h"
+
+/* TODO: Ensure the USB stack works on Big-Endian devices */
+#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__)
+_Static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__, "Error: USB Descriptors rely on Little-Endian memory layout!");
+#endif
+
+#ifndef CDC_CLIENT_ID_VENDOR
+#define CDC_CLIENT_ID_VENDOR 0x16f9
+#endif
+
+#ifndef CDC_CLIENT_ID_PRODUCT
+#define CDC_CLIENT_ID_PRODUCT 0x0003
+#endif
+
+#ifndef CDC_CLIENT_BCD_DEVICE
+#define CDC_CLIENT_BCD_DEVICE 0x0200
+#endif
+
+#ifndef CDC_CLIENT_PROD_NAME
+#define CDC_CLIENT_PROD_NAME "Virtual COM Port"
+#endif
+
+#ifndef CDC_CLIENT_MFG_NAME
+#define CDC_CLIENT_MFG_NAME "Phoenix Systems"
+#endif
+
+_Static_assert((sizeof(CDC_CLIENT_MFG_NAME) - 1) * 2 <= sizeof(((usb_string_desc_t *)0)->wData),
+		"USB: Manufacturer name can be at most 128 characters long");
+_Static_assert((sizeof(CDC_CLIENT_PROD_NAME) - 1) * 2 <= sizeof(((usb_string_desc_t *)0)->wData),
+		"USB: Product name can be at most 128 characters long");
+
 
 struct {
 	usb_desc_list_t *descList;
@@ -56,9 +88,9 @@ static const usb_device_desc_t dDev = {
 	.bDeviceSubClass = 0,
 	.bDeviceProtocol = 0,
 	.bMaxPacketSize0 = 64,
-	.idVendor = 0x16f9,
-	.idProduct = 0x0003,
-	.bcdDevice = 0x0200,
+	.idVendor = CDC_CLIENT_ID_VENDOR,
+	.idProduct = CDC_CLIENT_ID_PRODUCT,
+	.bcdDevice = CDC_CLIENT_BCD_DEVICE,
 	.iManufacturer = 1,
 	.iProduct = 2,
 	.iSerialNumber = 0,
@@ -179,9 +211,9 @@ static const usb_endpoint_desc_t dEpIN = {
 
 /* String Data: Manufacturer = "Phoenix Systems" */
 static const usb_string_desc_t dStrMan = {
-	.bLength = 2 * 15 + 2,
+	.bLength = ((sizeof(CDC_CLIENT_MFG_NAME) - 1) * 2) + 2,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = { 'P', 0, 'h', 0, 'o', 0, 'e', 0, 'n', 0, 'i', 0, 'x', 0, ' ', 0, 'S', 0, 'y', 0, 's', 0, 't', 0, 'e', 0, 'm', 0, 's', 0 }
+	.wData16 = USB_WIDE_STR(CDC_CLIENT_MFG_NAME),
 };
 
 
@@ -195,9 +227,9 @@ static const usb_string_desc_t dStr0 = {
 
 /* String Data: Product = "Virtual COM Port" */
 static const usb_string_desc_t dStrProd = {
-	.bLength = 2 * 16 + 2,
+	.bLength = ((sizeof(CDC_CLIENT_PROD_NAME) - 1) * 2) + 2,
 	.bDescriptorType = USB_DESC_STRING,
-	.wData = { 'V', 0, 'i', 0, 'r', 0, 't', 0, 'u', 0, 'a', 0, 'l', 0, ' ', 0, 'C', 0, 'O', 0, 'M', 0, ' ', 0, 'P', 0, 'o', 0, 'r', 0, 't', 0 }
+	.wData16 = USB_WIDE_STR(CDC_CLIENT_PROD_NAME),
 };
 
 

--- a/libusb/include/usb.h
+++ b/libusb/include/usb.h
@@ -101,6 +101,10 @@
 
 #define USB_TIMEOUT 5000000
 
+#define USB_WIDE_STR_HELPER(x) u##x
+#define USB_WIDE_STR(x)        USB_WIDE_STR_HELPER(x)
+
+
 enum { pid_out = 0xe1, pid_in = 0x69, pid_setup = 0x2d };
 
 
@@ -180,7 +184,10 @@ typedef struct {
 typedef struct {
 	uint8_t bLength;
 	uint8_t bDescriptorType;
-	uint8_t wData[256];
+	union {
+		uint8_t wData[256];
+		uint16_t wData16[128];
+	};
 } __attribute__((packed)) usb_string_desc_t;
 
 


### PR DESCRIPTION
TASK: PP-403

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change introduces macros for defining custom values for the following parameters:
- Vendor ID
- Product ID
- Device release number (`bcdDevice`)
- Product name string
- Manufacturer name string
<!--- Describe your changes shortly -->

## Motivation and Context
When non-technical users use USB devices, it is often not obvious to them what "Virtual COM Port" is. Setting a custom, user-friendly name makes it easier for users to know which device they want to connect to. Additionally, it just looks more professional, which can be important when presenting software to potential clients.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [x] Tested by hand on: armv8m-stm32n6.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
