### PR TITLE
Cherry-pick USB and Wi-Fi changes for release 3.3

### DIFF
--- a/libusb/include/usb.h
+++ b/libusb/include/usb.h
@@ -197,6 +197,13 @@ typedef struct {
 /* generic descriptor
  * used when there is no defined descriptor (e.g. HID descriptor or Report descriptor) */
 typedef struct {
+	uint8_t bLength;
+	uint8_t bDescriptorType;
+	uint8_t wData[];
+} __attribute__((packed)) usb_generic_desc_t;
+
+
+typedef struct {
 	uint8_t bFunctionLength;
 	uint8_t bDescriptorType;
 	uint8_t bDescriptorSubtype;

--- a/libusb/include/usbprocdriver.h
+++ b/libusb/include/usbprocdriver.h
@@ -18,7 +18,12 @@
 #include <usbdriver.h>
 
 
-int usb_driverProcRun(usb_driver_t *driver, void *args);
+/*
+ * Initializes the given driver and spawns a thread pool of nthreads of prio priority to handle usbhost events.
+ * Threads concurrently process insertion/deletion/completion events with provided driver->handlers. Calls exit(1)
+ * on any failure.
+ */
+__attribute__((noreturn)) void usb_driverProcRun(usb_driver_t *driver, unsigned int prio, unsigned int nthreads, void *args);
 
 
 #endif

--- a/libusb/procdriver.c
+++ b/libusb/procdriver.c
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <sys/msg.h>
+#include <sys/mman.h>
 #include <sys/threads.h>
 #include <sys/list.h>
 #include <string.h>
@@ -24,30 +25,24 @@
 #include "log.h"
 
 
-#ifndef USB_N_UMSG_THREADS
-#define USB_N_UMSG_THREADS 2
-#endif
-
-#ifndef USB_UMSG_PRIO
-#define USB_UMSG_PRIO 3
-#endif
-
-
 #undef LIBUSB_LOG_TAG
 #define LIBUSB_LOG_TAG "libusb(procdriver)"
+
+#ifndef USB_UMSG_STACKSIZE
+#define USB_UMSG_STACKSIZE 2048
+#endif
 
 
 static usb_pipeOps_t usbprocdrv_pipeOps;
 
 
 static struct {
-	char ustack[USB_N_UMSG_THREADS - 1][2048] __attribute__((aligned(8)));
 	unsigned srvport;
 	unsigned drvport;
 } usbprocdrv_common;
 
 
-static void usb_thread(void *arg)
+__attribute__((noreturn)) static void usb_thread(void *arg)
 {
 	usb_driver_t *drv = (usb_driver_t *)arg;
 	msg_t msg = { 0 };
@@ -111,17 +106,19 @@ static int usb_connect(usb_driver_t *drv)
 }
 
 
-int usb_driverProcRun(usb_driver_t *drv, void *args)
+__attribute__((noreturn)) void usb_driverProcRun(usb_driver_t *drv, unsigned int prio, unsigned int nthreads, void *args)
 {
 	oid_t oid;
 	int ret, i;
+	void *stack;
 
 	/* usb_driverProcRun is invoked iff drivers are in the proc variant */
 	drv->pipeOps = &usbprocdrv_pipeOps;
 
 	ret = drv->ops.init(drv, args);
 	if (ret < 0) {
-		return -1;
+		log_error("%s: failed to initialize the driver [%d]", drv->name, ret);
+		exit(1);
 	}
 
 	usb_hostLookup(&oid);
@@ -129,26 +126,32 @@ int usb_driverProcRun(usb_driver_t *drv, void *args)
 
 	ret = portCreate(&usbprocdrv_common.drvport);
 	if (ret != 0) {
-		return -1;
+		log_error("%s: failed to create port [%d]", drv->name, ret);
+		exit(1);
 	}
 
 	ret = usb_connect(drv);
 	if (ret < 0) {
-		return -1;
+		log_error("%s: failed to connect to usbhost [%d]", drv->name, ret);
+		exit(1);
 	}
 
-	for (i = 0; i < USB_N_UMSG_THREADS - 1; i++) {
-		ret = beginthread(usb_thread, USB_UMSG_PRIO, usbprocdrv_common.ustack[i], sizeof(usbprocdrv_common.ustack[i]), drv);
+	for (i = 0; i + 1 < nthreads; i++) {
+		stack = mmap(NULL, USB_UMSG_STACKSIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		if (stack == MAP_FAILED) {
+			log_error("%s: mmap failed", drv->name);
+			exit(1);
+		}
+
+		ret = beginthread(usb_thread, prio, stack, USB_UMSG_STACKSIZE, drv);
 		if (ret < 0) {
-			log_error("fail to beginthread ret: %d\n", ret);
-			return -1;
+			log_error("%s: failed to start thread [%d]\n", drv->name, ret);
+			exit(1);
 		}
 	}
 
-	priority(USB_UMSG_PRIO);
+	priority(prio);
 	usb_thread(drv);
-
-	return 0;
 }
 
 

--- a/usb/dev.c
+++ b/usb/dev.c
@@ -262,7 +262,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 		uint8_t len = ((struct usb_desc_header *)ptr)->bLength;
 
 		if ((len < sizeof(struct usb_desc_header)) || (len > size)) {
-			log_error("Invalid descriptor size: %u\n", len);
+			log_error("Invalid descriptor size: %u", len);
 			break;
 		}
 
@@ -286,7 +286,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 					}
 				}
 				else {
-					log_error("Interface descriptor with invalid size\n");
+					log_error("Interface descriptor with invalid size");
 					ret = -1;
 				}
 				break;
@@ -314,7 +314,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 					}
 				}
 				else {
-					log_error("Endpoint descriptor with invalid size\n");
+					log_error("Endpoint descriptor with invalid size");
 					ret = -1;
 				}
 				break;
@@ -327,17 +327,19 @@ static int usb_getConfiguration(usb_dev_t *dev)
 					dev->desc.bDeviceProtocol = ((usb_interface_association_desc_t *)ptr)->bFunctionProtocol;
 				}
 				else {
-					log_error("Interface assoctiation descriptor with invalid size\n");
+					log_error("Interface association descriptor with invalid size");
 					ret = -1;
 				}
 				break;
 
-			case USB_DESC_CS_INTERFACE:
-				/* TODO: save Class-Specific Functional Descriptors to be used by device drivers - silently ignored for now */
-				break;
-
 			default:
-				log_error("Ignoring unkonown descriptor type: 0x%02x\n", ((struct usb_desc_header *)ptr)->bDescriptorType);
+				/* assume unknown descriptor type is a class-specific or vendor-specific functional descriptor */
+				if (lastAlternateSetting != 0) {
+					/* TODO: handle alternate setting maybe */
+				}
+				else if (lastIfNum >= 0) {
+					dev->ifs[lastIfNum].func = (usb_generic_desc_t *)ptr;
+				}
 				break;
 		}
 
@@ -346,7 +348,7 @@ static int usb_getConfiguration(usb_dev_t *dev)
 	}
 
 	for (size_t i = 0; i < dev->nifs; i++) {
-		if ((dev->ifs[i].desc == NULL) || (dev->ifs[i].eps == NULL)) {
+		if ((dev->ifs[i].desc == NULL) || ((dev->ifs[i].eps == NULL) && (dev->ifs[i].func == NULL))) {
 			/* Data missing */
 			ret = -1;
 			break;

--- a/usb/dev.c
+++ b/usb/dev.c
@@ -679,7 +679,6 @@ int usb_devEnumerate(usb_dev_t *dev)
 	else if (usb_drvBind(dev, usb_devOnDrvBindCb) != 0) {
 		log_msg("Fail to match drivers for device\n");
 		/* TODO: make device orphaned */
-		return -1;
 	}
 
 	return 0;

--- a/usb/dev.h
+++ b/usb/dev.h
@@ -35,6 +35,7 @@ typedef struct {
 typedef struct {
 	usb_interface_desc_t *desc;
 	usb_endpoint_desc_t *eps;
+	usb_generic_desc_t *func;
 	void *classDesc;
 	usb_lenStr_t name;
 

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -43,6 +43,10 @@
 #undef USB_LOG_TAG
 #define USB_LOG_TAG "usbhub"
 
+#ifndef USB_HUB_TT_WORKAROUND
+#define USB_HUB_TT_WORKAROUND 0
+#endif
+
 
 typedef struct _hub_event {
 	struct _hub_event *next, *prev;
@@ -177,13 +181,6 @@ static int hub_interruptInit(usb_dev_t *hub)
 }
 
 
-static int hub_isTT(usb_dev_t *dev)
-{
-	/* TODO support MTTs */
-	return dev->desc.bDeviceClass == USB_CLASS_HUB && dev->desc.bDeviceProtocol == USB_HUB_PROTO_SINGLE_TT;
-}
-
-
 static int hub_requestStatus(usb_dev_t *hub)
 {
 	return usb_transferSubmit(hub->statusTransfer, hub->irqPipe, NULL);
@@ -262,6 +259,14 @@ static int hub_portDebounce(usb_dev_t *hub, int port)
 }
 
 
+#if USB_HUB_TT_WORKAROUND
+static int hub_isTT(usb_dev_t *dev)
+{
+	/* TODO support MTTs */
+	return dev->desc.bDeviceClass == USB_CLASS_HUB && dev->desc.bDeviceProtocol == USB_HUB_PROTO_SINGLE_TT;
+}
+
+
 static void hub_ttAdd(usb_dev_t *hub)
 {
 	mutexLock(hub_common.lock);
@@ -276,14 +281,17 @@ static void hub_ttRemove(usb_dev_t *hub)
 	LIST_REMOVE(&hub_common.tts, hub);
 	mutexUnlock(hub_common.lock);
 }
+#endif
 
 
 static void hub_devDisconnect(usb_dev_t *dev, bool silent)
 {
-	usb_devDisconnected(dev, silent);
+#if USB_HUB_TT_WORKAROUND
 	if (hub_isTT(dev)) {
 		hub_ttRemove(dev);
 	}
+#endif
+	usb_devDisconnected(dev, silent);
 }
 
 
@@ -399,6 +407,7 @@ static uint32_t hub_getStatus(usb_dev_t *hub)
 }
 
 
+#if USB_HUB_TT_WORKAROUND
 static void hub_ttStatus(void)
 {
 	usb_dev_t *hub;
@@ -415,6 +424,7 @@ static void hub_ttStatus(void)
 		}
 	} while ((hub = hub->next) != hub_common.tts);
 }
+#endif
 
 
 static void hub_thread(void *args)
@@ -426,6 +436,7 @@ static void hub_thread(void *args)
 	for (;;) {
 		mutexLock(hub_common.lock);
 		while (hub_common.events == NULL) {
+#if USB_HUB_TT_WORKAROUND
 			condWait(hub_common.cond, hub_common.lock, HUB_TT_POLL_DELAY_MS);
 
 			/*
@@ -437,6 +448,9 @@ static void hub_thread(void *args)
 			mutexUnlock(hub_common.lock);
 			hub_ttStatus();
 			mutexLock(hub_common.lock);
+#else
+			condWait(hub_common.cond, hub_common.lock, 0);
+#endif
 		}
 		ev = hub_common.events;
 		LIST_REMOVE(&hub_common.events, ev);
@@ -504,14 +518,16 @@ int hub_conf(usb_dev_t *hub)
 	if (hub_interruptInit(hub) != 0)
 		return -EINVAL;
 
+#if USB_HUB_TT_WORKAROUND
 	if (hub_isTT(hub)) {
-		// FIXME Interrupt pipe notifications from tier 2 TTs never come, which is
-		// either a quirk in currently tested hw or an issue in the hcd driver
-
-		// In addition to request an interrupt request, actively poll the status as well
-		// for as a workaround
+		/*
+		 * FIXME Interrupt pipe notifications from tier 2 TTs never come on ia32,
+		 * which is either a quirk in currently tested hw or an issue in the hcd driver.
+		 * As a workaround, try to receive interrupt requests AND actively poll the status.
+		 */
 		hub_ttAdd(hub);
 	}
+#endif
 
 	return hub_requestStatus(hub);
 }

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -37,16 +37,10 @@
 #define HUB_DEBOUNCE_STABLE  100000
 #define HUB_DEBOUNCE_PERIOD  25000
 #define HUB_DEBOUNCE_TIMEOUT 1500000
-#define HUB_TT_POLL_DELAY_MS 1000000
 
 
 #undef USB_LOG_TAG
 #define USB_LOG_TAG "usbhub"
-
-#ifndef USB_HUB_TT_WORKAROUND
-#define USB_HUB_TT_WORKAROUND 0
-#endif
-
 
 typedef struct _hub_event {
 	struct _hub_event *next, *prev;
@@ -259,38 +253,8 @@ static int hub_portDebounce(usb_dev_t *hub, int port)
 }
 
 
-#if USB_HUB_TT_WORKAROUND
-static int hub_isTT(usb_dev_t *dev)
-{
-	/* TODO support MTTs */
-	return dev->desc.bDeviceClass == USB_CLASS_HUB && dev->desc.bDeviceProtocol == USB_HUB_PROTO_SINGLE_TT;
-}
-
-
-static void hub_ttAdd(usb_dev_t *hub)
-{
-	mutexLock(hub_common.lock);
-	LIST_ADD(&hub_common.tts, hub);
-	mutexUnlock(hub_common.lock);
-}
-
-
-static void hub_ttRemove(usb_dev_t *hub)
-{
-	mutexLock(hub_common.lock);
-	LIST_REMOVE(&hub_common.tts, hub);
-	mutexUnlock(hub_common.lock);
-}
-#endif
-
-
 static void hub_devDisconnect(usb_dev_t *dev, bool silent)
 {
-#if USB_HUB_TT_WORKAROUND
-	if (hub_isTT(dev)) {
-		hub_ttRemove(dev);
-	}
-#endif
 	usb_devDisconnected(dev, silent);
 }
 
@@ -407,26 +371,6 @@ static uint32_t hub_getStatus(usb_dev_t *hub)
 }
 
 
-#if USB_HUB_TT_WORKAROUND
-static void hub_ttStatus(void)
-{
-	usb_dev_t *hub;
-	int i;
-
-	hub = hub_common.tts;
-	if (hub == NULL) {
-		return;
-	}
-
-	do {
-		for (i = 0; i < hub->nports; i++) {
-			hub_portstatus(hub, i + 1);
-		}
-	} while ((hub = hub->next) != hub_common.tts);
-}
-#endif
-
-
 static void hub_thread(void *args)
 {
 	hub_event_t *ev;
@@ -436,21 +380,7 @@ static void hub_thread(void *args)
 	for (;;) {
 		mutexLock(hub_common.lock);
 		while (hub_common.events == NULL) {
-#if USB_HUB_TT_WORKAROUND
-			condWait(hub_common.cond, hub_common.lock, HUB_TT_POLL_DELAY_MS);
-
-			/*
-			 * hub_ttStatus may lead to usb_devEnumerate call which may call hub_conf that
-			 * tries to obtain this lock. FIXME? It may be better to separate the enumeration
-			 * from the connect status polling logic, but as this polling loop is a
-			 * part of L2 TT workaround, the problem may be easier to solve itself in the root
-			 */
-			mutexUnlock(hub_common.lock);
-			hub_ttStatus();
-			mutexLock(hub_common.lock);
-#else
 			condWait(hub_common.cond, hub_common.lock, 0);
-#endif
 		}
 		ev = hub_common.events;
 		LIST_REMOVE(&hub_common.events, ev);
@@ -517,17 +447,6 @@ int hub_conf(usb_dev_t *hub)
 
 	if (hub_interruptInit(hub) != 0)
 		return -EINVAL;
-
-#if USB_HUB_TT_WORKAROUND
-	if (hub_isTT(hub)) {
-		/*
-		 * FIXME Interrupt pipe notifications from tier 2 TTs never come on ia32,
-		 * which is either a quirk in currently tested hw or an issue in the hcd driver.
-		 * As a workaround, try to receive interrupt requests AND actively poll the status.
-		 */
-		hub_ttAdd(hub);
-	}
-#endif
 
 	return hub_requestStatus(hub);
 }

--- a/usb/hub.c
+++ b/usb/hub.c
@@ -427,7 +427,16 @@ static void hub_thread(void *args)
 		mutexLock(hub_common.lock);
 		while (hub_common.events == NULL) {
 			condWait(hub_common.cond, hub_common.lock, HUB_TT_POLL_DELAY_MS);
+
+			/*
+			 * hub_ttStatus may lead to usb_devEnumerate call which may call hub_conf that
+			 * tries to obtain this lock. FIXME? It may be better to separate the enumeration
+			 * from the connect status polling logic, but as this polling loop is a
+			 * part of L2 TT workaround, the problem may be easier to solve itself in the root
+			 */
+			mutexUnlock(hub_common.lock);
 			hub_ttStatus();
+			mutexLock(hub_common.lock);
 		}
 		ev = hub_common.events;
 		LIST_REMOVE(&hub_common.events, ev);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Cherry-picks into the 3.3 release branch the following:

Fixes for TT enumeration:
* usb/hub: fix deadlock on successful TT enumeration
* usb/hub: make TT workaround opt-in
* usb/hub: drop TT workaround
* usb/dev: handle class-specific functional descriptors
* usb/dev: ignore failure to bind the driver

Change usb_driverProcRun signature to allow setting number of threads and their priorities:
* !libusb/procdriver: accept prio and nthreads as usb_driverProcRun args
* libusb/procdriver: make usb_driverProcRun explicitly exit on failure

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [x] This PR needs additional PRs to work:
    - https://github.com/phoenix-rtos/phoenix-rtos-devices/pull/659
- [ ] I will merge this PR by myself when appropriate.
