### PR TITLE
usbmon: introduce USB hub monitor

### DIFF
--- a/libusb/include/usbdriver.h
+++ b/libusb/include/usbdriver.h
@@ -127,6 +127,13 @@ typedef struct {
 
 
 typedef struct {
+	enum { usb_usbmon_start,
+		usb_usbmon_stop } action;
+	uint32_t snaplen; /* max payload bytes to capture (0 = default) */
+} usb_usbmon_t;
+
+
+typedef struct {
 	enum { usb_msg_connect,
 		usb_msg_insertion,
 		usb_msg_deletion,
@@ -134,7 +141,8 @@ typedef struct {
 		usb_msg_open,
 		usb_msg_urbcmd,
 		usb_msg_completion,
-		usb_msg_devdesc } type;
+		usb_msg_devdesc,
+		usb_msg_usbmon } type;
 
 	union {
 		usb_connect_t connect;
@@ -145,6 +153,7 @@ typedef struct {
 		usb_deletion_t deletion;
 		usb_completion_t completion;
 		usb_devdesc_t devdesc;
+		usb_usbmon_t usbmon;
 	};
 } usb_msg_t;
 

--- a/usb/Makefile
+++ b/usb/Makefile
@@ -6,9 +6,14 @@
 
 NAME := usb
 LOCAL_SRCS := usb.c dev.c drv.c hcd.c hub.c mem.c
-LOCAL_HEADERS := hcd.h hub.h dev.h drv.h usbhost.h
+LOCAL_HEADERS := hcd.h hub.h dev.h drv.h usbhost.h usbmon.h
 LIBS := $(USB_HCD_LIBS) $(USB_HOSTDRV_LIBS) libusb
 DEPS := libusb
+
+ifdef USBMON
+  CFLAGS += -DUSBMON
+  LOCAL_SRCS += usbmon.c
+endif
 
 ifneq ($(USB_HOSTDRV_LIBS),)
  CFLAGS += -DUSB_INTERNAL_ONLY

--- a/usb/usb.c
+++ b/usb/usb.c
@@ -34,6 +34,7 @@
 #include "hcd.h"
 #include "hub.h"
 #include "log.h"
+#include "usbmon.h"
 
 #define N_STATUSTHRS   1
 #define STATUSTHR_PRIO 3
@@ -128,6 +129,8 @@ int usb_transferSubmit(usb_transfer_t *t, usb_pipe_t *pipe, handle_t *cond)
 		memset(t->buffer, 0, t->size);
 	mutexUnlock(usb_common.transferLock);
 
+	usbmon_submit(t, pipe);
+
 	if ((ret = hcd->ops->transferEnqueue(hcd, t, pipe)) != 0)
 		return ret;
 
@@ -160,6 +163,8 @@ void usb_transferFinished(usb_transfer_t *t, int status)
 		t->transferred = 0;
 		t->error = -status;
 	}
+
+	usbmon_complete(t);
 
 	/* If recipient is not HCD, this is an URB transfer */
 	if (t->recipient != usb_drvType_hcd) {
@@ -334,6 +339,22 @@ static void usb_msgthr(void *arg)
 					case usb_msg_devdesc:
 						msg.o.err = usb_devFindDescFromOid(umsg->devdesc.oid, msg.o.data);
 						break;
+					case usb_msg_usbmon:
+						if (umsg->usbmon.action == usb_usbmon_start) {
+							if (msg.i.data == NULL || msg.i.size == 0 || strnlen(msg.i.data, msg.i.size) == msg.i.size) {
+								msg.o.err = -EINVAL;
+							}
+							else {
+								msg.o.err = usbmon_start(msg.i.data, umsg->usbmon.snaplen);
+							}
+						}
+						else if (umsg->usbmon.action == usb_usbmon_stop) {
+							msg.o.err = usbmon_stop();
+						}
+						else {
+							msg.o.err = -EINVAL;
+						}
+						break;
 					default:
 						msg.o.err = -EINVAL;
 						log_error("unsupported usb_msg type: %d\n", umsg->type);
@@ -391,8 +412,35 @@ static void usb_statusthr(void *arg)
 int main(int argc, char *argv[])
 {
 	oid_t oid;
-	int i;
+	int i, opt;
 	usb_driver_t *drv;
+	const char *pcap_path = NULL;
+
+	while ((opt = getopt(argc, argv, "m:")) != -1) {
+		switch (opt) {
+			case 'm':
+				pcap_path = optarg;
+				break;
+			default:
+				log_error("Usage: usb [-m pcap_path]\n");
+				return 1;
+		}
+	}
+
+#ifdef USBMON
+	if (usbmon_init(pcap_path) != 0) {
+		log_error("Failed to initialize USB monitor\n");
+		return 1;
+	}
+	if (pcap_path != NULL) {
+		log_msg("USB monitoring enabled, writing to %s\n", pcap_path);
+	}
+#else
+	if (pcap_path != NULL) {
+		log_error("USB monitoring not compiled in (build with USBMON=1)\n");
+		return 1;
+	}
+#endif
 
 	if (mutexCreate(&usb_common.transferLock) != 0) {
 		log_error("Can't create mutex!\n");

--- a/usb/usbmon.c
+++ b/usb/usbmon.c
@@ -1,0 +1,559 @@
+/*
+ * Phoenix-RTOS
+ *
+ * USB bus monitor - PCAPng trace output
+ *
+ * Captures URB submissions and completions and writes them to a PCAPng file
+ * using LINKTYPE_USB_LINUX_MMAPPED (220) format, compatible with Wireshark.
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/threads.h>
+#include <sys/minmax.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "usbmon.h"
+#include "hcd.h"
+#include "log.h"
+
+#undef USB_LOG_TAG
+#define USB_LOG_TAG "usbmon"
+
+
+/* PCAPng block types */
+#define PCAPNG_BT_SHB 0x0A0D0D0Au /* Section Header Block */
+#define PCAPNG_BT_IDB 0x00000001u /* Interface Description Block */
+#define PCAPNG_BT_EPB 0x00000006u /* Enhanced Packet Block */
+
+/* PCAPng constants */
+#define PCAPNG_BOM          0x1A2B3C4Du
+#define PCAPNG_VERSION_MAJ  1
+#define PCAPNG_VERSION_MIN  0
+#define PCAPNG_LINKTYPE_USB 220 /* LINKTYPE_USB_LINUX_MMAPPED */
+
+/* Size of the USB monitor packet header (matches Linux struct usbmon_packet) */
+#define USBMON_PKT_SIZE 64
+
+/* Default maximum payload bytes captured per event */
+#define USBMON_MAX_DATA 256
+
+/* Maximum number of concurrently tracked URBs */
+#define USBMON_MAX_TRACKED 64
+
+/* EPB fixed overhead: block_type(4) + block_total_len(4) + iface_id(4) +
+ * ts_high(4) + ts_low(4) + cap_len(4) + orig_len(4) + trailing_len(4) = 32 */
+#define USBMON_EPB_OVERHEAD 32
+
+/* Transfer type values in PCAP/PCAPng USB format */
+enum {
+	PCAP_XFER_ISO = 0,
+	PCAP_XFER_INTR = 1,
+	PCAP_XFER_CTRL = 2,
+	PCAP_XFER_BULK = 3,
+};
+
+
+/* PCAPng option codes */
+#define PCAPNG_OPT_ENDOFOPT     0
+#define PCAPNG_OPT_IF_NAME      2
+#define PCAPNG_OPT_IF_DESC      3
+#define PCAPNG_OPT_SHB_USERAPPL 4
+#define PCAPNG_OPT_IF_TSRESOL   9
+
+
+/* PCAPng Enhanced Packet Block - fixed header portion */
+struct pcapng_epb_hdr {
+	uint32_t blockType;
+	uint32_t blockTotalLength;
+	uint32_t interfaceId;
+	uint32_t timestampHigh;
+	uint32_t timestampLow;
+	uint32_t capturedPacketLength;
+	uint32_t originalPacketLength;
+} __attribute__((packed));
+
+
+/*
+ * USB monitor packet header - LINKTYPE_USB_LINUX_MMAPPED.
+ * Layout matches Linux struct usbmon_packet (64 bytes total).
+ */
+struct usbmon_packet {
+	uint64_t id;          /*  0: URB ID (transfer pointer) */
+	uint8_t type;         /*  8: 'S' submit, 'C' complete, 'E' error */
+	uint8_t xferType;     /*  9: 0=iso, 1=intr, 2=ctrl, 3=bulk */
+	uint8_t epnum;        /* 10: endpoint number | direction (bit 7) */
+	uint8_t devnum;       /* 11: device address */
+	uint16_t busnum;      /* 12: bus number */
+	uint8_t flagSetup;    /* 14: 0 if setup data present */
+	uint8_t flagData;     /* 15: 0 if payload data present */
+	int64_t tsSec;        /* 16: timestamp seconds */
+	int32_t tsUsec;       /* 24: timestamp microseconds */
+	int32_t status;       /* 28: URB status (negative errno on error) */
+	uint32_t length;      /* 32: data length (requested or actual) */
+	uint32_t lenCap;      /* 36: header + captured data length */
+	union {               /* 40: */
+		uint8_t setup[8]; /* setup packet for control S-type */
+		struct {
+			int32_t errorCount;
+			int32_t numdesc;
+		} iso;
+	} s;
+	int32_t interval;   /* 48: polling interval (intr/iso) */
+	int32_t startFrame; /* 52: ISO start frame */
+	uint32_t xferFlags; /* 56: transfer flags */
+	uint32_t ndesc;     /* 60: number of ISO descriptors */
+} __attribute__((packed));
+
+
+_Static_assert(sizeof(struct usbmon_packet) == USBMON_PKT_SIZE,
+		"usbmon_packet must be exactly 64 bytes");
+
+
+/* Tracking entry for correlating submission with completion */
+typedef struct {
+	uintptr_t id; /* Transfer pointer (0 = slot empty) */
+	uint8_t epnum;
+	uint8_t devnum;
+	uint16_t busnum;
+	int interval;
+} usbmon_entry_t;
+
+
+static struct {
+	int fd;
+	handle_t lock;
+	uint32_t snaplen;
+	usbmon_entry_t entries[USBMON_MAX_TRACKED];
+	/* Scratch buffer for one EPB: overhead + USB header + max payload */
+	uint8_t buf[USBMON_EPB_OVERHEAD + USBMON_PKT_SIZE + USBMON_MAX_DATA];
+} usbmon_common = { .fd = -1 };
+
+
+/* Map transfer type enum to PCAP transfer type */
+static uint8_t usbmon_pcapXfer(int type)
+{
+	switch (type) {
+		case usb_transfer_control: return PCAP_XFER_CTRL;
+		case usb_transfer_isochronous: return PCAP_XFER_ISO;
+		case usb_transfer_bulk: return PCAP_XFER_BULK;
+		case usb_transfer_interrupt: return PCAP_XFER_INTR;
+		default: return 0;
+	}
+}
+
+
+/* Store pipe info so completion can look it up without having the pipe */
+static void usbmon_track(uintptr_t id, uint8_t epnum, uint8_t devnum, uint16_t busnum, int interval)
+{
+	int i, empty = -1;
+	for (i = 0; i < USBMON_MAX_TRACKED; i++) {
+		if (usbmon_common.entries[i].id == id) {
+			/* Reuse existing slot (re-submitted transfer) */
+			usbmon_common.entries[i].epnum = epnum;
+			usbmon_common.entries[i].devnum = devnum;
+			usbmon_common.entries[i].busnum = busnum;
+			usbmon_common.entries[i].interval = interval;
+			return;
+		}
+		if ((empty < 0) && (usbmon_common.entries[i].id == 0)) {
+			empty = i;
+		}
+	}
+
+	if (empty >= 0) {
+		usbmon_common.entries[empty].id = id;
+		usbmon_common.entries[empty].epnum = epnum;
+		usbmon_common.entries[empty].devnum = devnum;
+		usbmon_common.entries[empty].busnum = busnum;
+		usbmon_common.entries[empty].interval = interval;
+	}
+	/* else: table full - completion will use fallback values */
+}
+
+
+static usbmon_entry_t *usbmon_lookup(uintptr_t id)
+{
+	for (int i = 0; i < USBMON_MAX_TRACKED; i++) {
+		if (usbmon_common.entries[i].id == id) {
+			return &usbmon_common.entries[i];
+		}
+	}
+	return NULL;
+}
+
+
+/*
+ * Write one PCAPng Enhanced Packet Block: EPB header + usbmon_packet + payload.
+ * Caller must hold usbmon_common.lock.
+ */
+static void usbmon_writeEvent(uint8_t eventType, usb_transfer_t *t, uint8_t epnum, uint8_t devnum,
+		uint16_t busnum, int interval, const void *data, size_t dataLen)
+{
+	struct pcapng_epb_hdr *epb;
+	struct usbmon_packet *pkt;
+	struct timespec ts;
+	uint64_t tsUs;
+	size_t cap;
+	size_t pktCap, pktOrig, pktPadded;
+	uint32_t blockTotalLen;
+	ssize_t wr;
+
+	cap = (dataLen > usbmon_common.snaplen) ? usbmon_common.snaplen : dataLen;
+
+	pktCap = USBMON_PKT_SIZE + cap;
+	pktOrig = USBMON_PKT_SIZE + dataLen;
+	pktPadded = (pktCap + 3u) & ~3u;
+	blockTotalLen = (uint32_t)(USBMON_EPB_OVERHEAD + pktPadded);
+
+	/* Zero entire record area */
+	memset(usbmon_common.buf, 0, blockTotalLen);
+
+	/* Timestamp */
+	if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+		ts.tv_sec = 0;
+		ts.tv_nsec = 0;
+	}
+	tsUs = (uint64_t)ts.tv_sec * 1000000u + (uint64_t)(ts.tv_nsec / 1000);
+
+	/* EPB header */
+	epb = (struct pcapng_epb_hdr *)usbmon_common.buf;
+	epb->blockType = PCAPNG_BT_EPB;
+	epb->blockTotalLength = blockTotalLen;
+	epb->interfaceId = 0;
+	epb->timestampHigh = (uint32_t)(tsUs >> 32);
+	epb->timestampLow = (uint32_t)(tsUs & 0xFFFFFFFFu);
+	epb->capturedPacketLength = (uint32_t)pktCap;
+	epb->originalPacketLength = (uint32_t)pktOrig;
+
+	/* USB monitor packet header */
+	pkt = (struct usbmon_packet *)(usbmon_common.buf + sizeof(*epb));
+	pkt->id = (uint64_t)(uintptr_t)t;
+	pkt->type = eventType;
+	pkt->xferType = usbmon_pcapXfer(t->type);
+	pkt->epnum = epnum;
+	pkt->devnum = devnum;
+	pkt->busnum = busnum;
+
+	/* Setup packet (only for control submissions) */
+	if ((eventType == 'S') && (t->type == usb_transfer_control) &&
+			(t->setup != NULL)) {
+		pkt->flagSetup = 0; /* setup data present */
+		memcpy(pkt->s.setup, t->setup, sizeof(pkt->s.setup));
+	}
+	else {
+		pkt->flagSetup = '-';
+	}
+
+	/* Data flag: 0 = payload follows header, non-zero = no payload */
+	if (cap > 0) {
+		pkt->flagData = 0;
+	}
+	else {
+		pkt->flagData = (t->direction == usb_dir_in) ? '<' : '>';
+	}
+
+	pkt->tsSec = (int64_t)ts.tv_sec;
+	pkt->tsUsec = (int32_t)(ts.tv_nsec / 1000);
+
+	if (eventType == 'C') {
+		pkt->status = (t->error != 0) ? -(int32_t)t->error : 0;
+	}
+
+	pkt->length = (eventType == 'S') ? (uint32_t)t->size : (uint32_t)t->transferred;
+	pkt->lenCap = (uint32_t)(USBMON_PKT_SIZE + cap);
+	pkt->interval = (int32_t)interval;
+
+	/* Copy payload data after usbmon header */
+	if ((cap > 0) && (data != NULL)) {
+		memcpy(usbmon_common.buf + sizeof(*epb) + USBMON_PKT_SIZE, data, cap);
+	}
+
+	/* Trailing Block Total Length (after padded packet data) */
+	memcpy(usbmon_common.buf + sizeof(*epb) + pktPadded, &blockTotalLen, sizeof(blockTotalLen));
+
+	/* Write entire EPB atomically */
+	wr = write(usbmon_common.fd, usbmon_common.buf, blockTotalLen);
+	if (wr != (ssize_t)blockTotalLen) {
+		log_error("pcapng write failed: %d\n", (wr < 0) ? errno : EIO);
+	}
+}
+
+
+/*
+ * Write a PCAPng option (code + length + value padded to 4 bytes) into buf
+ * at position off. Returns the new offset.
+ */
+static uint32_t usbmon_writeOpt(uint8_t *buf, uint32_t off, uint16_t code, const void *val, uint16_t len)
+{
+	memcpy(buf + off, &code, 2);
+	off += 2;
+	memcpy(buf + off, &len, 2);
+	off += 2;
+
+	if (len > 0) {
+		memcpy(buf + off, val, len);
+		off += len;
+		while ((off & 3u) != 0) {
+			buf[off++] = 0;
+		}
+	}
+
+	return off;
+}
+
+
+/* Finish a PCAPng block: fill blockType and blockTotalLength fields. */
+static uint32_t usbmon_finishBlock(uint8_t *buf, uint32_t off, uint32_t blockType)
+{
+	uint32_t blockLen = off + 4; /* +4 for trailing blockTotalLength */
+
+	memcpy(buf, &blockType, 4);
+	memcpy(buf + 4, &blockLen, 4);
+	memcpy(buf + off, &blockLen, 4);
+
+	return blockLen;
+}
+
+
+/* Open a PCAPng file and write the SHB + IDB. Caller must hold lock or ensure exclusivity. */
+static int usbmon_open(const char *pcapPath, uint32_t snaplen)
+{
+	uint8_t hdr[128];
+	uint32_t off, total;
+	uint32_t val32;
+	uint16_t val16;
+	int64_t val64;
+	uint8_t tsresol;
+
+	if (pcapPath == NULL) {
+		return -EINVAL;
+	}
+
+	usbmon_common.snaplen = snaplen == 0 ? USBMON_MAX_DATA : min(USBMON_MAX_DATA, snaplen);
+
+	usbmon_common.fd = open(pcapPath, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (usbmon_common.fd < 0) {
+		log_error("cannot open %s: %d\n", pcapPath, errno);
+		return -errno;
+	}
+
+	memset(usbmon_common.entries, 0, sizeof(usbmon_common.entries));
+
+	/* --- Section Header Block --- */
+	off = 8; /* skip block_type + block_total_length (filled by finish) */
+
+	val32 = PCAPNG_BOM;
+	memcpy(hdr + off, &val32, 4);
+	off += 4;
+
+	val16 = PCAPNG_VERSION_MAJ;
+	memcpy(hdr + off, &val16, 2);
+	off += 2;
+	val16 = PCAPNG_VERSION_MIN;
+	memcpy(hdr + off, &val16, 2);
+	off += 2;
+
+	val64 = -1; /* section length: unspecified */
+	memcpy(hdr + off, &val64, 8);
+	off += 8;
+
+	off = usbmon_writeOpt(hdr, off, PCAPNG_OPT_SHB_USERAPPL, "phoenix-rtos-usbmon", 19);
+	off = usbmon_writeOpt(hdr, off, PCAPNG_OPT_ENDOFOPT, NULL, 0);
+
+	total = usbmon_finishBlock(hdr, off, PCAPNG_BT_SHB);
+
+	if (write(usbmon_common.fd, hdr, total) != (ssize_t)total) {
+		log_error("failed to write pcapng SHB\n");
+		close(usbmon_common.fd);
+		usbmon_common.fd = -1;
+		return -EIO;
+	}
+
+	/* --- Interface Description Block --- */
+	off = 8;
+
+	val16 = PCAPNG_LINKTYPE_USB;
+	memcpy(hdr + off, &val16, 2);
+	off += 2;
+	val16 = 0; /* reserved */
+	memcpy(hdr + off, &val16, 2);
+	off += 2;
+
+	val32 = USBMON_PKT_SIZE + snaplen;
+	memcpy(hdr + off, &val32, 4);
+	off += 4;
+
+	off = usbmon_writeOpt(hdr, off, PCAPNG_OPT_IF_NAME, "usbmon0", 7);
+	off = usbmon_writeOpt(hdr, off, PCAPNG_OPT_IF_DESC, "Phoenix-RTOS USB Monitor", 24);
+	tsresol = 6; /* 10^-6 = microseconds */
+	off = usbmon_writeOpt(hdr, off, PCAPNG_OPT_IF_TSRESOL, &tsresol, 1);
+	off = usbmon_writeOpt(hdr, off, PCAPNG_OPT_ENDOFOPT, NULL, 0);
+
+	total = usbmon_finishBlock(hdr, off, PCAPNG_BT_IDB);
+
+	if (write(usbmon_common.fd, hdr, total) != (ssize_t)total) {
+		log_error("failed to write pcapng IDB\n");
+		close(usbmon_common.fd);
+		usbmon_common.fd = -1;
+		return -EIO;
+	}
+
+	return 0;
+}
+
+
+int usbmon_init(const char *pcapPath)
+{
+	int ret;
+
+	if (mutexCreate(&usbmon_common.lock) != 0) {
+		return -ENOMEM;
+	}
+
+	if (pcapPath != NULL) {
+		ret = usbmon_open(pcapPath, 0);
+		if (ret < 0) {
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+
+void usbmon_destroy(void)
+{
+	if (usbmon_common.fd >= 0) {
+		close(usbmon_common.fd);
+		usbmon_common.fd = -1;
+	}
+}
+
+
+int usbmon_start(const char *pcapPath, uint32_t snaplen)
+{
+	int ret;
+
+	mutexLock(usbmon_common.lock);
+
+	if (usbmon_common.fd >= 0) {
+		mutexUnlock(usbmon_common.lock);
+		return -EBUSY;
+	}
+
+	ret = usbmon_open(pcapPath, snaplen);
+
+	mutexUnlock(usbmon_common.lock);
+
+	return ret;
+}
+
+
+int usbmon_stop(void)
+{
+	mutexLock(usbmon_common.lock);
+
+	if (usbmon_common.fd < 0) {
+		mutexUnlock(usbmon_common.lock);
+		return -ENOENT;
+	}
+
+	close(usbmon_common.fd);
+	usbmon_common.fd = -1;
+
+	mutexUnlock(usbmon_common.lock);
+
+	return 0;
+}
+
+
+void usbmon_submit(usb_transfer_t *t, usb_pipe_t *pipe)
+{
+	const void *data = NULL;
+	size_t dataLen = 0;
+	int interval;
+	uint16_t busnum;
+	uint8_t epnum, devnum;
+
+	if (usbmon_common.fd < 0) {
+		return;
+	}
+
+	epnum = (uint8_t)(pipe->num & 0x7f);
+	if (t->direction == usb_dir_in) {
+		epnum |= 0x80;
+	}
+
+	devnum = (uint8_t)(pipe->dev->address & 0x7f);
+	busnum = (uint16_t)(pipe->dev->hcd->num & 0xffff);
+
+	interval = 0;
+	if ((t->type == usb_transfer_interrupt) || (t->type == usb_transfer_isochronous)) {
+		interval = pipe->interval;
+	}
+
+	/* For OUT transfers, capture the outgoing data */
+	if ((t->direction == usb_dir_out) && (t->size > 0) && (t->buffer != NULL)) {
+		data = t->buffer;
+		dataLen = t->size;
+	}
+
+	mutexLock(usbmon_common.lock);
+
+	if (usbmon_common.fd >= 0) {
+		usbmon_track((uintptr_t)t, epnum, devnum, busnum, interval);
+		usbmon_writeEvent('S', t, epnum, devnum, busnum, interval, data, dataLen);
+	}
+
+	mutexUnlock(usbmon_common.lock);
+}
+
+
+void usbmon_complete(usb_transfer_t *t)
+{
+	usbmon_entry_t *e;
+	const void *data = NULL;
+	size_t dataLen = 0;
+	int interval = 0;
+	uint16_t busnum = 0;
+	uint8_t epnum, devnum = 0;
+
+	if (usbmon_common.fd < 0) {
+		return;
+	}
+
+	/* Fallback: use direction from transfer, endpoint 0 */
+	epnum = (t->direction == usb_dir_in) ? 0x80 : 0x00;
+
+	mutexLock(usbmon_common.lock);
+
+	if (usbmon_common.fd >= 0) {
+		e = usbmon_lookup((uintptr_t)t);
+		if (e != NULL) {
+			epnum = e->epnum;
+			devnum = e->devnum;
+			busnum = e->busnum;
+			interval = e->interval;
+			e->id = 0; /* Free tracking slot */
+		}
+
+		/* For IN transfers, capture the received data */
+		if ((t->direction == usb_dir_in) && (t->transferred > 0) && (t->buffer != NULL)) {
+			data = t->buffer;
+			dataLen = t->transferred;
+		}
+
+		usbmon_writeEvent('C', t, epnum, devnum, busnum, interval, data, dataLen);
+	}
+
+	mutexUnlock(usbmon_common.lock);
+}

--- a/usb/usbmon.h
+++ b/usb/usbmon.h
@@ -1,0 +1,92 @@
+/*
+ * Phoenix-RTOS
+ *
+ * USB bus monitor - PCAP trace output
+ *
+ * Copyright 2026 Phoenix Systems
+ * Author: Adam Greloch
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+#ifndef _USBMON_H_
+#define _USBMON_H_
+
+#include <errno.h>
+
+#include "usbhost.h"
+
+
+#ifdef USBMON
+
+
+/* Initialize the USB monitor and open the PCAP output file. Returns 0 on success, negative errno on failure. */
+int usbmon_init(const char *pcapPath);
+
+
+/* Shut down the USB monitor and close the PCAP file. */
+void usbmon_destroy(void);
+
+
+/* Start capturing to the given PCAPng file (runtime control). Returns 0 on success. */
+int usbmon_start(const char *pcapPath, uint32_t snaplen);
+
+
+/* Stop capturing and close the PCAPng file (runtime control). Returns 0 on success. */
+int usbmon_stop(void);
+
+
+/* Record a submission of t on a pipe. */
+void usbmon_submit(usb_transfer_t *t, usb_pipe_t *pipe);
+
+
+/* Record a completion of t. */
+void usbmon_complete(usb_transfer_t *t);
+
+
+#else /* !USBMON */
+
+
+static inline int usbmon_init(const char *pcapPath)
+{
+	(void)pcapPath;
+	return 0;
+}
+
+
+static inline void usbmon_destroy(void)
+{
+}
+
+
+static inline int usbmon_start(const char *pcapPath, uint32_t snaplen)
+{
+	(void)pcapPath;
+	(void)snaplen;
+	return -ENOSYS;
+}
+
+
+static inline int usbmon_stop(void)
+{
+	return -ENOSYS;
+}
+
+
+static inline void usbmon_submit(usb_transfer_t *t, usb_pipe_t *pipe)
+{
+	(void)t;
+	(void)pipe;
+}
+
+
+static inline void usbmon_complete(usb_transfer_t *t)
+{
+	(void)t;
+}
+
+
+#endif /* USBMON */
+
+#endif /* _USBMON_H_ */


### PR DESCRIPTION
Introduces a simple usbmon that captures IN/OUT traffic through the HCD to PCAPng file. Capture can be toggled in run-time by `-m <pcapng path>` and through message API.

To reduce (a potentially disastrous) time/mem overhead on heavy transfers, the packets are trimmed to 256 bytes max (enough for the USB header) and can be trimmed even further through the `snaplen` param.

For now, the monitor is left as a compile-time opt-in through the USBMON env var.

Assisted-by: Claude:claude-opus-4-6
TASK: RTOS-1342

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes shortly -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

<!--- In case of breaking change - please advice here what needs to be done in dependent projects. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing linter checks and tests passed.
- [ ] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
