### PR TITLE
libusb/procdriver: replace strncpy() with memcpy() to silence compiler warning

### DIFF
--- a/libusb/procdriver.c
+++ b/libusb/procdriver.c
@@ -100,7 +100,7 @@ static int usb_connect(usb_driver_t *drv)
 	umsg->type = usb_msg_connect;
 	umsg->connect.port = usbprocdrv_common.drvport;
 	umsg->connect.nfilters = nfilters;
-	strncpy(umsg->connect.name, drv->name, USB_DRVNAME_MAX);
+	memcpy(umsg->connect.name, drv->name, USB_DRVNAME_MAX);
 
 	return msgSend(usbprocdrv_common.srvport, &msg) < 0;
 }


### PR DESCRIPTION
## Description
gcc complains about using `strncpy()` usage:
```
midash/phoenix-rtos-usb/libusb/procdriver.c:103:9: error: 'strncpy' specified bound 10 equals destination size [-Werror=stringop-truncation]
  103 |         strncpy(umsg->connect.name, drv->name, USB_DRVNAME_MAX);
```

"Fix" it by replacing with `memcpy()` over the whole buffer.

## Motivation and Context
See above

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (refactoring, style fixes, git/CI config, submodule management, no code logic changes)

## How Has This Been Tested?
- [ ] Already covered by automatic testing.
- [ ] New test added: (add PR link here).
- [ ] Tested by hand on: (list targets here).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing linter checks and tests passed.
- [x] My changes generate no new compilation warnings for any of the targets.

## Special treatment

- [ ] This PR needs additional PRs to work (list the PRs, preferably in merge-order).
- [ ] I will merge this PR by myself when appropriate.
